### PR TITLE
C#8 support

### DIFF
--- a/UnityPython.BackEnd.CodeGen/CSAST.cs
+++ b/UnityPython.BackEnd.CodeGen/CSAST.cs
@@ -487,7 +487,8 @@ namespace CSAST
                 name.Doc(),
                 doc_arguments,
                 body.Select(x => x.Doc()).ToArray(),
-                Public: false
+                Public: false,
+                Static: true
             );
         }
     }

--- a/UnityPython.BackEnd.CodeGen/CodeGen.cs
+++ b/UnityPython.BackEnd.CodeGen/CodeGen.cs
@@ -56,16 +56,18 @@ public static class ExtCodeGen
         return $"{dt.Name}.{t.Name}".Doc();
     }
 
-    public static Doc GenerateMethod(Doc retype, Doc name, (Doc name, Doc type)[] arguments, Doc[] body, bool Public = false, bool Static = false, bool Override = false)
+    public static Doc GenerateMethod(Doc retype, Doc name, (Doc name, Doc type)[] arguments, Doc[] body, bool Public = false, bool Static = false, bool Override = false, bool Virtual = false)
     {
         var head_str = "";
         if (Public)
-            head_str = "public " + head_str;
+            head_str += "public ";
         if (Static)
-            head_str = "static " + head_str;
+            head_str += "static ";
         else if (Override)
-            head_str = "override " + head_str;
-        var head = (Public ? "public ".Doc() : Empty) * retype + name * "(".Doc() * arguments.Select(x => x.type + x.name).Join(Comma) * ")".Doc();
+            head_str += "override ";
+        else if (Virtual)
+            head_str += "virtual ";
+        var head = head_str.Doc() + retype + name * "(".Doc() * arguments.Select(x => x.type + x.name).Join(Comma) * ")".Doc();
         return head * NewLine * VSep("{".Doc(),
             VSep(body).Indent(4),
         "}".Doc());

--- a/UnityPython.BackEnd.CodeGen/CodeGen.cs
+++ b/UnityPython.BackEnd.CodeGen/CodeGen.cs
@@ -56,17 +56,16 @@ public static class ExtCodeGen
         return $"{dt.Name}.{t.Name}".Doc();
     }
 
-    public static Doc GenerateMethod(Doc retype, Doc name, (Doc name, Doc type)[] arguments, Doc[] body, bool Public = false)
+    public static Doc GenerateMethod(Doc retype, Doc name, (Doc name, Doc type)[] arguments, Doc[] body, bool Public = false, bool Static = false, bool Override = false)
     {
+        var head_str = "";
+        if (Public)
+            head_str = "public " + head_str;
+        if (Static)
+            head_str = "static " + head_str;
+        else if (Override)
+            head_str = "override " + head_str;
         var head = (Public ? "public ".Doc() : Empty) * retype + name * "(".Doc() * arguments.Select(x => x.type + x.name).Join(Comma) * ")".Doc();
-        return head * NewLine * VSep("{".Doc(),
-            VSep(body).Indent(4),
-        "}".Doc());
-    }
-
-    public static Doc GenerateInterfaceMethod(Doc interfaceName, Doc retype, Doc name, (Doc name, Doc type)[] arguments, Doc[] body)
-    {
-        var head = retype + interfaceName * ".".Doc() * name * "(".Doc() * arguments.Select(x => x.type + x.name).Join(Comma) * ")".Doc();
         return head * NewLine * VSep("{".Doc(),
             VSep(body).Indent(4),
         "}".Doc());

--- a/UnityPython.BackEnd.CodeGen/CodeGenConfig.cs
+++ b/UnityPython.BackEnd.CodeGen/CodeGenConfig.cs
@@ -9,5 +9,4 @@ public static class CodeGenConfig
             .GetMethods(BindingFlags.Static | BindingFlags.Public)
             .Where(m => m.GetCustomAttribute<MagicMethod>() != null)
             .ToArray();
-    
 }

--- a/UnityPython.BackEnd.CodeGen/Gen_Object_Default.cs
+++ b/UnityPython.BackEnd.CodeGen/Gen_Object_Default.cs
@@ -59,15 +59,15 @@ public class Gen_ObjectDefault : HasNamespace
         RequiredNamespace.Remove(entry.Namespace);
         RequiredNamespace.Select(x => $"using {x};\n").ForEach(write);
         var x = VSep(
+            $"namespace {entry.Namespace}".Doc(),
+            "{".Doc(),
             VSep(
-                $"namespace {entry.Namespace}".Doc(),
-                "{".Doc(),
-                "public partial interface".Doc() + entry.Name.Doc(),
+                "public abstract partial class".Doc() + entry.Name.Doc(),
                 "{".Doc(),
                 defs.Join(NewLine).Indent(4),
                 "}".Doc()
             ).Indent(4),
-        "}".Doc()
+            "}".Doc()
         );
         x.Render(write);
         write("\n");

--- a/UnityPython.BackEnd.CodeGen/Gen_Object_Default.cs
+++ b/UnityPython.BackEnd.CodeGen/Gen_Object_Default.cs
@@ -53,7 +53,7 @@ public class Gen_ObjectDefault : HasNamespace
                                   .SurroundedBy(Parens)
                         * ";".Doc(),
             };
-            defs.Add(GenerateMethod(meth.ReturnType.RefGen(this), meth.Name.Doc(), sig_Args, body));
+            defs.Add(GenerateMethod(meth.ReturnType.RefGen(this), meth.Name.Doc(), sig_Args, body, Public: true, Virtual: true));
         }
 
         RequiredNamespace.Remove(entry.Namespace);

--- a/UnityPython.BackEnd.CodeGen/UnityPython.BackEnd.CodeGen.csproj
+++ b/UnityPython.BackEnd.CodeGen/UnityPython.BackEnd.CodeGen.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>

--- a/UnityPython.BackEnd.CodeGen/UnityPython.BackEnd.CodeGen.csproj
+++ b/UnityPython.BackEnd.CodeGen/UnityPython.BackEnd.CodeGen.csproj
@@ -7,7 +7,7 @@
 
  <ItemGroup>
     <Reference Include="UnityPython">
-      <HintPath>../UnityPython.BackEnd/bin/Release/net6/UnityPython.dll</HintPath>
+      <HintPath>../UnityPython.BackEnd/bin/Release/netstandard2.1/UnityPython.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/UnityPython.BackEnd/RunTests.cs
+++ b/UnityPython.BackEnd/RunTests.cs
@@ -7,6 +7,17 @@ using Traffy;
 using Traffy.Objects;
 using static Traffy.Objects.ExtMonoAsyn;
 
+public abstract class X
+{
+    public virtual int f()
+    {
+        return 1;
+    }
+}
+
+public class Y : X
+{
+}
 public class App
 {
     public static TrObject time()
@@ -20,16 +31,19 @@ public class App
         Initialization.Prelude(TrSharpFunc.FromFunc("time", time));
         ModuleSystem.LoadDirectory(argv[0]);
         var test_modules = ModuleSystem.Modules.Keys.Where(x => x.Split(".").Last().StartsWith("test_")).ToList();
-        try
+        
+        foreach (var module_name in test_modules)
+            ModuleSystem.ImportModule(module_name);
+    
+        return 0;
+    }
+#else
+    public static int Main()
+    {
+        foreach(var mi in typeof(Y).GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public))
         {
-            foreach (var module_name in test_modules)
-                ModuleSystem.ImportModule(module_name);
-        }
-        catch (Exception e)
-        {
-            var exc = RTS.exc_frombare(e);
-            Console.WriteLine(exc.GetStackTrace());
-            return 1;
+            var mf = mi.GetBaseDefinition();
+            Console.WriteLine($"{mi.Name} {mf.Name}");
         }
         return 0;
     }

--- a/UnityPython.BackEnd/UnityPython.Tests.csproj
+++ b/UnityPython.BackEnd/UnityPython.Tests.csproj
@@ -1,19 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <Compile Include="src/**/*.cs;generated-src/**/*.cs" />
-  </ItemGroup>
   <PropertyGroup>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-     <OutputType>Library</OutputType>
-     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-     <TargetFramework>netstandard2.1</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <TargetFramework>net6</TargetFramework>
      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
      <Optimize>true</Optimize>
      <DefineConstants>NUNITY;TESTS</DefineConstants>
-    <!-- <Nullable>enable</Nullable> -->
   </PropertyGroup>
 
   <!-- <ItemGroup>

--- a/UnityPython.BackEnd/UnityPython.csproj
+++ b/UnityPython.BackEnd/UnityPython.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>9</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/UnityPython.BackEnd/UnityPython.csproj
+++ b/UnityPython.BackEnd/UnityPython.csproj
@@ -1,22 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <LangVersion>9</LangVersion>
+  </PropertyGroup>
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6</TargetFramework>
      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-     <Optimize>true</Optimize>
+     <Optimize>false</Optimize>
      <DefineConstants>NUNITY;TESTS</DefineConstants>
     <!-- <Nullable>enable</Nullable> -->
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- <ItemGroup>
     <Reference Include="UnityEngine">
       <HintPath>./UnityEngine.dll</HintPath>
     </Reference>
-  </ItemGroup>
+  </ItemGroup> -->
 
-  <ItemGroup>
+  <!-- <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-  </ItemGroup>
+  </ItemGroup> -->
 
 </Project>

--- a/UnityPython.BackEnd/UnityPython.csproj
+++ b/UnityPython.BackEnd/UnityPython.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6</TargetFramework>
      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-     <Optimize>false</Optimize>
+     <Optimize>true</Optimize>
      <DefineConstants>NUNITY;TESTS</DefineConstants>
     <!-- <Nullable>enable</Nullable> -->
   </PropertyGroup>

--- a/UnityPython.BackEnd/build-code.sh
+++ b/UnityPython.BackEnd/build-code.sh
@@ -1,0 +1,4 @@
+rm -rf generated-src/BuiltinBindings.cs
+rm -rf generated-src/MethodBindings/
+dotnet publish -c Release UnityPython.csproj
+dotnet run --project ../UnityPython.BackEnd.CodeGen/UnityPython.BackEnd.CodeGen.csproj

--- a/UnityPython.BackEnd/build.sh
+++ b/UnityPython.BackEnd/build.sh
@@ -1,3 +1,0 @@
-rm -rf generated-src/BuiltinBindings.cs
-rm -rf generated-src/MethodBindings/
-dotnet publish -c Release && dotnet run --project ../UnityPython.BackEnd.CodeGen/UnityPython.BackEnd.CodeGen.csproj

--- a/UnityPython.BackEnd/generated-src/BuiltinBindings.cs
+++ b/UnityPython.BackEnd/generated-src/BuiltinBindings.cs
@@ -16,7 +16,7 @@ namespace Traffy
             Initialization.Prelude(TrSharpFunc.FromFunc("any", any));
             Initialization.Prelude(TrSharpFunc.FromFunc("zip", zip));
             Initialization.Prelude(TrSharpFunc.FromFunc("enumerate", enumerate));
-            Traffy.Objects.TrObject __bind_reversed(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_reversed(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -30,7 +30,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("reversed", __bind_reversed));
-            Traffy.Objects.TrObject __bind_sorted(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_sorted(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -54,7 +54,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("sorted", __bind_sorted));
-            Traffy.Objects.TrObject __bind_sum(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_sum(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -80,7 +80,7 @@ namespace Traffy
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("sum", __bind_sum));
             Initialization.Prelude(TrSharpFunc.FromFunc("print", print));
-            Traffy.Objects.TrObject __bind_stacktrace(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_stacktrace(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -94,7 +94,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("stacktrace", __bind_stacktrace));
-            Traffy.Objects.TrObject __bind_abs(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_abs(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -108,7 +108,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("abs", __bind_abs));
-            Traffy.Objects.TrObject __bind_bin(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_bin(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -122,7 +122,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("bin", __bind_bin));
-            Traffy.Objects.TrObject __bind_chr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_chr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -136,7 +136,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("chr", __bind_chr));
-            Traffy.Objects.TrObject __bind_ord(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_ord(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -150,7 +150,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("ord", __bind_ord));
-            Traffy.Objects.TrObject __bind_oct(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_oct(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -164,7 +164,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("oct", __bind_oct));
-            Traffy.Objects.TrObject __bind_hex(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_hex(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -178,7 +178,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("hex", __bind_hex));
-            Traffy.Objects.TrObject __bind_hasattr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_hasattr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -194,7 +194,7 @@ namespace Traffy
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("hasattr", __bind_hasattr));
             Initialization.Prelude(TrSharpFunc.FromFunc("getattr", getattr));
-            Traffy.Objects.TrObject __bind_setattr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_setattr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -210,7 +210,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("setattr", __bind_setattr));
-            Traffy.Objects.TrObject __bind_len(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_len(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -224,7 +224,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("len", __bind_len));
-            Traffy.Objects.TrObject __bind_hash(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_hash(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -238,7 +238,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("hash", __bind_hash));
-            Traffy.Objects.TrObject __bind_pow(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_pow(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -253,7 +253,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("pow", __bind_pow));
-            Traffy.Objects.TrObject __bind_repr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_repr(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -267,7 +267,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("repr", __bind_repr));
-            Traffy.Objects.TrObject __bind_round(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_round(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -292,7 +292,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("round", __bind_round));
-            Traffy.Objects.TrObject __bind_isinstance(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_isinstance(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -307,7 +307,7 @@ namespace Traffy
                 }
             }
             Initialization.Prelude(TrSharpFunc.FromFunc("isinstance", __bind_isinstance));
-            Traffy.Objects.TrObject __bind_issubclass(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_issubclass(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrClassMethod.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrClassMethod.cs
@@ -8,11 +8,11 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __read___func__(Traffy.Objects.TrObject _arg)
+            static  Traffy.Objects.TrObject __read___func__(Traffy.Objects.TrObject _arg)
             {
                 return Box.Apply(((Traffy.Objects.TrClassMethod)_arg).__func__);
             }
-            void __write___func__(Traffy.Objects.TrObject _arg,Traffy.Objects.TrObject _value)
+            static  void __write___func__(Traffy.Objects.TrObject _arg,Traffy.Objects.TrObject _value)
             {
                 ((Traffy.Objects.TrClassMethod)_arg).__func__ = Unbox.Apply(THint<Traffy.Objects.TrObject>.Unique,_value);
             }

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrGenerator.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrGenerator.cs
@@ -8,7 +8,7 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __bind_send(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_send(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrInt.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrInt.cs
@@ -8,7 +8,7 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __bind___new__(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind___new__(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -23,7 +23,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["__new__"] = TrStaticMethod.Bind(CLASS.Name + "." + "__new__", __bind___new__);
-            Traffy.Objects.TrObject __bind_from_bytes(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_from_bytes(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrIter.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrIter.cs
@@ -8,7 +8,7 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __bind___new__(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind___new__(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrList.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrList.cs
@@ -8,7 +8,7 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __bind_compare(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_compare(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -23,7 +23,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["compare"] = TrSharpFunc.FromFunc("compare", __bind_compare);
-            Traffy.Objects.TrObject __bind_copy(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_copy(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -37,7 +37,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["copy"] = TrSharpFunc.FromFunc("copy", __bind_copy);
-            Traffy.Objects.TrObject __bind_append(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_append(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -52,7 +52,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["append"] = TrSharpFunc.FromFunc("append", __bind_append);
-            Traffy.Objects.TrObject __bind_extend(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_extend(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -67,7 +67,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["extend"] = TrSharpFunc.FromFunc("extend", __bind_extend);
-            Traffy.Objects.TrObject __bind_insert(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_insert(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -83,7 +83,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["insert"] = TrSharpFunc.FromFunc("insert", __bind_insert);
-            Traffy.Objects.TrObject __bind_pop(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_pop(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -108,7 +108,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["pop"] = TrSharpFunc.FromFunc("pop", __bind_pop);
-            Traffy.Objects.TrObject __bind_remove(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_remove(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -123,7 +123,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["remove"] = TrSharpFunc.FromFunc("remove", __bind_remove);
-            Traffy.Objects.TrObject __bind_reverse(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_reverse(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -137,7 +137,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["reverse"] = TrSharpFunc.FromFunc("reverse", __bind_reverse);
-            Traffy.Objects.TrObject __bind_clear(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_clear(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -151,7 +151,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["clear"] = TrSharpFunc.FromFunc("clear", __bind_clear);
-            Traffy.Objects.TrObject __bind_find(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_find(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -196,7 +196,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["find"] = TrSharpFunc.FromFunc("find", __bind_find);
-            Traffy.Objects.TrObject __bind_index(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_index(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -241,7 +241,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["index"] = TrSharpFunc.FromFunc("index", __bind_index);
-            Traffy.Objects.TrObject __bind_count(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_count(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {
@@ -256,7 +256,7 @@ namespace Traffy.Objects
                 }
             }
             CLASS["count"] = TrSharpFunc.FromFunc("count", __bind_count);
-            Traffy.Objects.TrObject __bind_sort(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
+            static  Traffy.Objects.TrObject __bind_sort(BList<TrObject> __args,Dictionary<TrObject,TrObject> __kwargs)
             {
                 switch(__args.Count)
                 {

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrProperty.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrProperty.cs
@@ -8,13 +8,13 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __read_getter(Traffy.Objects.TrObject _arg)
+            static  Traffy.Objects.TrObject __read_getter(Traffy.Objects.TrObject _arg)
             {
                 return Box.Apply(((Traffy.Objects.TrProperty)_arg).getter);
             }
             Action<TrObject, TrObject> __write_getter = null;
             CLASS["getter"] = TrProperty.Create(CLASS.Name + ".getter", __read_getter, __write_getter);
-            Traffy.Objects.TrObject __read_setter(Traffy.Objects.TrObject _arg)
+            static  Traffy.Objects.TrObject __read_setter(Traffy.Objects.TrObject _arg)
             {
                 return Box.Apply(((Traffy.Objects.TrProperty)_arg).setter);
             }

--- a/UnityPython.BackEnd/generated-src/MethodBindings/TrSharpMethod.cs
+++ b/UnityPython.BackEnd/generated-src/MethodBindings/TrSharpMethod.cs
@@ -8,20 +8,20 @@ namespace Traffy.Objects
         [Mark(Initialization.TokenBuiltinInit)]
         static void BindMethods()
         {
-            Traffy.Objects.TrObject __read___func__(Traffy.Objects.TrObject _arg)
+            static  Traffy.Objects.TrObject __read___func__(Traffy.Objects.TrObject _arg)
             {
                 return Box.Apply(((Traffy.Objects.TrSharpMethod)_arg).__func__);
             }
-            void __write___func__(Traffy.Objects.TrObject _arg,Traffy.Objects.TrObject _value)
+            static  void __write___func__(Traffy.Objects.TrObject _arg,Traffy.Objects.TrObject _value)
             {
                 ((Traffy.Objects.TrSharpMethod)_arg).__func__ = Unbox.Apply(THint<Traffy.Objects.TrObject>.Unique,_value);
             }
             CLASS["__func__"] = TrProperty.Create(CLASS.Name + ".__func__", __read___func__, __write___func__);
-            Traffy.Objects.TrObject __read___self__(Traffy.Objects.TrObject _arg)
+            static  Traffy.Objects.TrObject __read___self__(Traffy.Objects.TrObject _arg)
             {
                 return Box.Apply(((Traffy.Objects.TrSharpMethod)_arg).__self__);
             }
-            void __write___self__(Traffy.Objects.TrObject _arg,Traffy.Objects.TrObject _value)
+            static  void __write___self__(Traffy.Objects.TrObject _arg,Traffy.Objects.TrObject _value)
             {
                 ((Traffy.Objects.TrSharpMethod)_arg).__self__ = Unbox.Apply(THint<Traffy.Objects.TrObject>.Unique,_value);
             }

--- a/UnityPython.BackEnd/generated-src/Traffy.Objects/Class.ClassInitHelpers.cs
+++ b/UnityPython.BackEnd/generated-src/Traffy.Objects/Class.ClassInitHelpers.cs
@@ -62,55 +62,55 @@ namespace Traffy.Objects
         {
             var ownership = typeof(T).GetInterfaceMethodSource();
             if (ownership.Contains("__init__"))
-                cls[MagicNames.i___init__] = TrSharpFunc.FromFunc(cls.Name + ".__init__", (self,arg0,arg1) => ((T)self).__init__(arg0,arg1));
+                cls[MagicNames.i___init__] = TrSharpFunc.FromFunc(cls.Name + ".__init__", (self, arg0, arg1) => ((T)self).__init__(arg0, arg1));
             if (ownership.Contains("__str__"))
                 cls[MagicNames.i___str__] = TrSharpFunc.FromFunc(cls.Name + ".__str__", (self) => ((T)self).__str__());
             if (ownership.Contains("__repr__"))
                 cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((T)self).__repr__());
             if (ownership.Contains("__next__"))
-                cls[MagicNames.i___next__] = TrSharpFunc.FromFunc(cls.Name + ".__next__", (self,arg0) => ((T)self).__next__(arg0));
+                cls[MagicNames.i___next__] = TrSharpFunc.FromFunc(cls.Name + ".__next__", (self, arg0) => ((T)self).__next__(arg0));
             if (ownership.Contains("__add__"))
-                cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self,arg0) => ((T)self).__add__(arg0));
+                cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self, arg0) => ((T)self).__add__(arg0));
             if (ownership.Contains("__sub__"))
-                cls[MagicNames.i___sub__] = TrSharpFunc.FromFunc(cls.Name + ".__sub__", (self,arg0) => ((T)self).__sub__(arg0));
+                cls[MagicNames.i___sub__] = TrSharpFunc.FromFunc(cls.Name + ".__sub__", (self, arg0) => ((T)self).__sub__(arg0));
             if (ownership.Contains("__mul__"))
-                cls[MagicNames.i___mul__] = TrSharpFunc.FromFunc(cls.Name + ".__mul__", (self,arg0) => ((T)self).__mul__(arg0));
+                cls[MagicNames.i___mul__] = TrSharpFunc.FromFunc(cls.Name + ".__mul__", (self, arg0) => ((T)self).__mul__(arg0));
             if (ownership.Contains("__matmul__"))
-                cls[MagicNames.i___matmul__] = TrSharpFunc.FromFunc(cls.Name + ".__matmul__", (self,arg0) => ((T)self).__matmul__(arg0));
+                cls[MagicNames.i___matmul__] = TrSharpFunc.FromFunc(cls.Name + ".__matmul__", (self, arg0) => ((T)self).__matmul__(arg0));
             if (ownership.Contains("__floordiv__"))
-                cls[MagicNames.i___floordiv__] = TrSharpFunc.FromFunc(cls.Name + ".__floordiv__", (self,arg0) => ((T)self).__floordiv__(arg0));
+                cls[MagicNames.i___floordiv__] = TrSharpFunc.FromFunc(cls.Name + ".__floordiv__", (self, arg0) => ((T)self).__floordiv__(arg0));
             if (ownership.Contains("__truediv__"))
-                cls[MagicNames.i___truediv__] = TrSharpFunc.FromFunc(cls.Name + ".__truediv__", (self,arg0) => ((T)self).__truediv__(arg0));
+                cls[MagicNames.i___truediv__] = TrSharpFunc.FromFunc(cls.Name + ".__truediv__", (self, arg0) => ((T)self).__truediv__(arg0));
             if (ownership.Contains("__mod__"))
-                cls[MagicNames.i___mod__] = TrSharpFunc.FromFunc(cls.Name + ".__mod__", (self,arg0) => ((T)self).__mod__(arg0));
+                cls[MagicNames.i___mod__] = TrSharpFunc.FromFunc(cls.Name + ".__mod__", (self, arg0) => ((T)self).__mod__(arg0));
             if (ownership.Contains("__pow__"))
-                cls[MagicNames.i___pow__] = TrSharpFunc.FromFunc(cls.Name + ".__pow__", (self,arg0) => ((T)self).__pow__(arg0));
+                cls[MagicNames.i___pow__] = TrSharpFunc.FromFunc(cls.Name + ".__pow__", (self, arg0) => ((T)self).__pow__(arg0));
             if (ownership.Contains("__bitand__"))
-                cls[MagicNames.i___bitand__] = TrSharpFunc.FromFunc(cls.Name + ".__bitand__", (self,arg0) => ((T)self).__bitand__(arg0));
+                cls[MagicNames.i___bitand__] = TrSharpFunc.FromFunc(cls.Name + ".__bitand__", (self, arg0) => ((T)self).__bitand__(arg0));
             if (ownership.Contains("__bitor__"))
-                cls[MagicNames.i___bitor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitor__", (self,arg0) => ((T)self).__bitor__(arg0));
+                cls[MagicNames.i___bitor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitor__", (self, arg0) => ((T)self).__bitor__(arg0));
             if (ownership.Contains("__bitxor__"))
-                cls[MagicNames.i___bitxor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitxor__", (self,arg0) => ((T)self).__bitxor__(arg0));
+                cls[MagicNames.i___bitxor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitxor__", (self, arg0) => ((T)self).__bitxor__(arg0));
             if (ownership.Contains("__lshift__"))
-                cls[MagicNames.i___lshift__] = TrSharpFunc.FromFunc(cls.Name + ".__lshift__", (self,arg0) => ((T)self).__lshift__(arg0));
+                cls[MagicNames.i___lshift__] = TrSharpFunc.FromFunc(cls.Name + ".__lshift__", (self, arg0) => ((T)self).__lshift__(arg0));
             if (ownership.Contains("__rshift__"))
-                cls[MagicNames.i___rshift__] = TrSharpFunc.FromFunc(cls.Name + ".__rshift__", (self,arg0) => ((T)self).__rshift__(arg0));
+                cls[MagicNames.i___rshift__] = TrSharpFunc.FromFunc(cls.Name + ".__rshift__", (self, arg0) => ((T)self).__rshift__(arg0));
             if (ownership.Contains("__hash__"))
                 cls[MagicNames.i___hash__] = TrSharpFunc.FromFunc(cls.Name + ".__hash__", (self) => ((T)self).__hash__());
             if (ownership.Contains("__call__"))
-                cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self,arg0,arg1) => ((T)self).__call__(arg0,arg1));
+                cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self, arg0, arg1) => ((T)self).__call__(arg0, arg1));
             if (ownership.Contains("__contains__"))
-                cls[MagicNames.i___contains__] = TrSharpFunc.FromFunc(cls.Name + ".__contains__", (self,arg0) => ((T)self).__contains__(arg0));
+                cls[MagicNames.i___contains__] = TrSharpFunc.FromFunc(cls.Name + ".__contains__", (self, arg0) => ((T)self).__contains__(arg0));
             if (ownership.Contains("__round__"))
-                cls[MagicNames.i___round__] = TrSharpFunc.FromFunc(cls.Name + ".__round__", (self,arg0) => ((T)self).__round__(arg0));
+                cls[MagicNames.i___round__] = TrSharpFunc.FromFunc(cls.Name + ".__round__", (self, arg0) => ((T)self).__round__(arg0));
             if (ownership.Contains("__reversed__"))
                 cls[MagicNames.i___reversed__] = TrSharpFunc.FromFunc(cls.Name + ".__reversed__", (self) => ((T)self).__reversed__());
             if (ownership.Contains("__getitem__"))
-                cls[MagicNames.i___getitem__] = TrSharpFunc.FromFunc(cls.Name + ".__getitem__", (self,arg0) => ((T)self).__getitem__(arg0));
+                cls[MagicNames.i___getitem__] = TrSharpFunc.FromFunc(cls.Name + ".__getitem__", (self, arg0) => ((T)self).__getitem__(arg0));
             if (ownership.Contains("__delitem__"))
-                cls[MagicNames.i___delitem__] = TrSharpFunc.FromFunc(cls.Name + ".__delitem__", (self,arg0) => ((T)self).__delitem__(arg0));
+                cls[MagicNames.i___delitem__] = TrSharpFunc.FromFunc(cls.Name + ".__delitem__", (self, arg0) => ((T)self).__delitem__(arg0));
             if (ownership.Contains("__setitem__"))
-                cls[MagicNames.i___setitem__] = TrSharpFunc.FromFunc(cls.Name + ".__setitem__", (self,arg0,arg1) => ((T)self).__setitem__(arg0,arg1));
+                cls[MagicNames.i___setitem__] = TrSharpFunc.FromFunc(cls.Name + ".__setitem__", (self, arg0, arg1) => ((T)self).__setitem__(arg0, arg1));
             if (ownership.Contains("__iter__"))
                 cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((T)self).__iter__());
             if (ownership.Contains("__await__"))
@@ -118,17 +118,17 @@ namespace Traffy.Objects
             if (ownership.Contains("__len__"))
                 cls[MagicNames.i___len__] = TrSharpFunc.FromFunc(cls.Name + ".__len__", (self) => ((T)self).__len__());
             if (ownership.Contains("__eq__"))
-                cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((T)self).__eq__(arg0));
+                cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self, arg0) => ((T)self).__eq__(arg0));
             if (ownership.Contains("__ne__"))
-                cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((T)self).__ne__(arg0));
+                cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self, arg0) => ((T)self).__ne__(arg0));
             if (ownership.Contains("__lt__"))
-                cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((T)self).__lt__(arg0));
+                cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self, arg0) => ((T)self).__lt__(arg0));
             if (ownership.Contains("__le__"))
-                cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((T)self).__le__(arg0));
+                cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self, arg0) => ((T)self).__le__(arg0));
             if (ownership.Contains("__gt__"))
-                cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((T)self).__gt__(arg0));
+                cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self, arg0) => ((T)self).__gt__(arg0));
             if (ownership.Contains("__ge__"))
-                cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((T)self).__ge__(arg0));
+                cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self, arg0) => ((T)self).__ge__(arg0));
             if (ownership.Contains("__neg__"))
                 cls[MagicNames.i___neg__] = TrSharpFunc.FromFunc(cls.Name + ".__neg__", (self) => ((T)self).__neg__());
             if (ownership.Contains("__invert__"))
@@ -142,7 +142,7 @@ namespace Traffy.Objects
             if (ownership.Contains("__enter__"))
                 cls[MagicNames.i___enter__] = TrSharpFunc.FromFunc(cls.Name + ".__enter__", (self) => ((T)self).__enter__());
             if (ownership.Contains("__exit__"))
-                cls[MagicNames.i___exit__] = TrSharpFunc.FromFunc(cls.Name + ".__exit__", (self,arg0,arg1,arg2) => ((T)self).__exit__(arg0,arg1,arg2));
+                cls[MagicNames.i___exit__] = TrSharpFunc.FromFunc(cls.Name + ".__exit__", (self, arg0, arg1, arg2) => ((T)self).__exit__(arg0, arg1, arg2));
         }
         public void InitInlineCacheForMagicMethods()
         {

--- a/UnityPython.BackEnd/generated-src/Traffy.Objects/Class.ClassInitHelpers.cs
+++ b/UnityPython.BackEnd/generated-src/Traffy.Objects/Class.ClassInitHelpers.cs
@@ -58,91 +58,317 @@ namespace Traffy.Objects
         }
 
 
+        static void BuiltinClassInit_TrBool(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrBool)self).__repr__());
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrBool)self).__bool__());
+        }
+        static void BuiltinClassInit_TrSharpFunc(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrSharpFunc)self).__repr__());
+            cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self,arg0,arg1) => ((Traffy.Objects.TrSharpFunc)self).__call__(arg0,arg1));
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrSharpFunc)self).__bool__());
+        }
+        static void BuiltinClassInit_TrByteArray(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrByteArray)self).__repr__());
+            cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__add__(arg0));
+            cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__eq__(arg0));
+            cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__ne__(arg0));
+            cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__lt__(arg0));
+            cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__le__(arg0));
+            cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__gt__(arg0));
+            cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((Traffy.Objects.TrByteArray)self).__ge__(arg0));
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrByteArray)self).__bool__());
+        }
+        static void BuiltinClassInit_TrBytes(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrBytes)self).__repr__());
+            cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__add__(arg0));
+            cls[MagicNames.i___hash__] = TrSharpFunc.FromFunc(cls.Name + ".__hash__", (self) => ((Traffy.Objects.TrBytes)self).__hash__());
+            cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__eq__(arg0));
+            cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__ne__(arg0));
+            cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__lt__(arg0));
+            cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__le__(arg0));
+            cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__gt__(arg0));
+            cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((Traffy.Objects.TrBytes)self).__ge__(arg0));
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrBytes)self).__bool__());
+        }
+        static void BuiltinClassInit_TrClassMethod(TrClass cls)
+        {
+        }
+        static void BuiltinClassInit_TrDict(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrDict)self).__repr__());
+            cls[MagicNames.i___reversed__] = TrSharpFunc.FromFunc(cls.Name + ".__reversed__", (self) => ((Traffy.Objects.TrDict)self).__reversed__());
+            cls[MagicNames.i___getitem__] = TrSharpFunc.FromFunc(cls.Name + ".__getitem__", (self,arg0) => ((Traffy.Objects.TrDict)self).__getitem__(arg0));
+            cls[MagicNames.i___delitem__] = TrSharpFunc.FromFunc(cls.Name + ".__delitem__", (self,arg0) => ((Traffy.Objects.TrDict)self).__delitem__(arg0));
+            cls[MagicNames.i___setitem__] = TrSharpFunc.FromFunc(cls.Name + ".__setitem__", (self,arg0,arg1) => ((Traffy.Objects.TrDict)self).__setitem__(arg0,arg1));
+            cls[MagicNames.i___len__] = TrSharpFunc.FromFunc(cls.Name + ".__len__", (self) => ((Traffy.Objects.TrDict)self).__len__());
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrDict)self).__bool__());
+        }
+        static void BuiltinClassInit_TrFloat(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrFloat)self).__repr__());
+            cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__add__(arg0));
+            cls[MagicNames.i___sub__] = TrSharpFunc.FromFunc(cls.Name + ".__sub__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__sub__(arg0));
+            cls[MagicNames.i___mul__] = TrSharpFunc.FromFunc(cls.Name + ".__mul__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__mul__(arg0));
+            cls[MagicNames.i___floordiv__] = TrSharpFunc.FromFunc(cls.Name + ".__floordiv__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__floordiv__(arg0));
+            cls[MagicNames.i___truediv__] = TrSharpFunc.FromFunc(cls.Name + ".__truediv__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__truediv__(arg0));
+            cls[MagicNames.i___mod__] = TrSharpFunc.FromFunc(cls.Name + ".__mod__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__mod__(arg0));
+            cls[MagicNames.i___pow__] = TrSharpFunc.FromFunc(cls.Name + ".__pow__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__pow__(arg0));
+            cls[MagicNames.i___round__] = TrSharpFunc.FromFunc(cls.Name + ".__round__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__round__(arg0));
+            cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__eq__(arg0));
+            cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__ne__(arg0));
+            cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__lt__(arg0));
+            cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__le__(arg0));
+            cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__gt__(arg0));
+            cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((Traffy.Objects.TrFloat)self).__ge__(arg0));
+            cls[MagicNames.i___neg__] = TrSharpFunc.FromFunc(cls.Name + ".__neg__", (self) => ((Traffy.Objects.TrFloat)self).__neg__());
+            cls[MagicNames.i___pos__] = TrSharpFunc.FromFunc(cls.Name + ".__pos__", (self) => ((Traffy.Objects.TrFloat)self).__pos__());
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrFloat)self).__bool__());
+        }
+        static void BuiltinClassInit_TrGenerator(TrClass cls)
+        {
+            cls[MagicNames.i___next__] = TrSharpFunc.FromFunc(cls.Name + ".__next__", (self,arg0) => ((Traffy.Objects.TrGenerator)self).__next__(arg0));
+            cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((Traffy.Objects.TrGenerator)self).__iter__());
+            cls[MagicNames.i___await__] = TrSharpFunc.FromFunc(cls.Name + ".__await__", (self) => ((Traffy.Objects.TrGenerator)self).__await__());
+        }
+        static void BuiltinClassInit_TrInt(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrInt)self).__repr__());
+            cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self,arg0) => ((Traffy.Objects.TrInt)self).__add__(arg0));
+            cls[MagicNames.i___sub__] = TrSharpFunc.FromFunc(cls.Name + ".__sub__", (self,arg0) => ((Traffy.Objects.TrInt)self).__sub__(arg0));
+            cls[MagicNames.i___mul__] = TrSharpFunc.FromFunc(cls.Name + ".__mul__", (self,arg0) => ((Traffy.Objects.TrInt)self).__mul__(arg0));
+            cls[MagicNames.i___floordiv__] = TrSharpFunc.FromFunc(cls.Name + ".__floordiv__", (self,arg0) => ((Traffy.Objects.TrInt)self).__floordiv__(arg0));
+            cls[MagicNames.i___truediv__] = TrSharpFunc.FromFunc(cls.Name + ".__truediv__", (self,arg0) => ((Traffy.Objects.TrInt)self).__truediv__(arg0));
+            cls[MagicNames.i___mod__] = TrSharpFunc.FromFunc(cls.Name + ".__mod__", (self,arg0) => ((Traffy.Objects.TrInt)self).__mod__(arg0));
+            cls[MagicNames.i___pow__] = TrSharpFunc.FromFunc(cls.Name + ".__pow__", (self,arg0) => ((Traffy.Objects.TrInt)self).__pow__(arg0));
+            cls[MagicNames.i___bitand__] = TrSharpFunc.FromFunc(cls.Name + ".__bitand__", (self,arg0) => ((Traffy.Objects.TrInt)self).__bitand__(arg0));
+            cls[MagicNames.i___bitor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitor__", (self,arg0) => ((Traffy.Objects.TrInt)self).__bitor__(arg0));
+            cls[MagicNames.i___bitxor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitxor__", (self,arg0) => ((Traffy.Objects.TrInt)self).__bitxor__(arg0));
+            cls[MagicNames.i___lshift__] = TrSharpFunc.FromFunc(cls.Name + ".__lshift__", (self,arg0) => ((Traffy.Objects.TrInt)self).__lshift__(arg0));
+            cls[MagicNames.i___rshift__] = TrSharpFunc.FromFunc(cls.Name + ".__rshift__", (self,arg0) => ((Traffy.Objects.TrInt)self).__rshift__(arg0));
+            cls[MagicNames.i___round__] = TrSharpFunc.FromFunc(cls.Name + ".__round__", (self,arg0) => ((Traffy.Objects.TrInt)self).__round__(arg0));
+            cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((Traffy.Objects.TrInt)self).__eq__(arg0));
+            cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((Traffy.Objects.TrInt)self).__ne__(arg0));
+            cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((Traffy.Objects.TrInt)self).__lt__(arg0));
+            cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((Traffy.Objects.TrInt)self).__le__(arg0));
+            cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((Traffy.Objects.TrInt)self).__gt__(arg0));
+            cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((Traffy.Objects.TrInt)self).__ge__(arg0));
+            cls[MagicNames.i___neg__] = TrSharpFunc.FromFunc(cls.Name + ".__neg__", (self) => ((Traffy.Objects.TrInt)self).__neg__());
+            cls[MagicNames.i___invert__] = TrSharpFunc.FromFunc(cls.Name + ".__invert__", (self) => ((Traffy.Objects.TrInt)self).__invert__());
+            cls[MagicNames.i___pos__] = TrSharpFunc.FromFunc(cls.Name + ".__pos__", (self) => ((Traffy.Objects.TrInt)self).__pos__());
+        }
+        static void BuiltinClassInit_TrIter(TrClass cls)
+        {
+            cls[MagicNames.i___next__] = TrSharpFunc.FromFunc(cls.Name + ".__next__", (self,arg0) => ((Traffy.Objects.TrIter)self).__next__(arg0));
+            cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((Traffy.Objects.TrIter)self).__iter__());
+        }
+        static void BuiltinClassInit_TrList(TrClass cls)
+        {
+            cls[MagicNames.i___str__] = TrSharpFunc.FromFunc(cls.Name + ".__str__", (self) => ((Traffy.Objects.TrList)self).__str__());
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrList)self).__repr__());
+            cls[MagicNames.i___getitem__] = TrSharpFunc.FromFunc(cls.Name + ".__getitem__", (self,arg0) => ((Traffy.Objects.TrList)self).__getitem__(arg0));
+            cls[MagicNames.i___delitem__] = TrSharpFunc.FromFunc(cls.Name + ".__delitem__", (self,arg0) => ((Traffy.Objects.TrList)self).__delitem__(arg0));
+            cls[MagicNames.i___setitem__] = TrSharpFunc.FromFunc(cls.Name + ".__setitem__", (self,arg0,arg1) => ((Traffy.Objects.TrList)self).__setitem__(arg0,arg1));
+            cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((Traffy.Objects.TrList)self).__iter__());
+            cls[MagicNames.i___len__] = TrSharpFunc.FromFunc(cls.Name + ".__len__", (self) => ((Traffy.Objects.TrList)self).__len__());
+            cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((Traffy.Objects.TrList)self).__eq__(arg0));
+            cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((Traffy.Objects.TrList)self).__ne__(arg0));
+            cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((Traffy.Objects.TrList)self).__lt__(arg0));
+            cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((Traffy.Objects.TrList)self).__le__(arg0));
+            cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((Traffy.Objects.TrList)self).__gt__(arg0));
+            cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((Traffy.Objects.TrList)self).__ge__(arg0));
+        }
+        static void BuiltinClassInit_TrSharpMethod(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrSharpMethod)self).__repr__());
+            cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self,arg0,arg1) => ((Traffy.Objects.TrSharpMethod)self).__call__(arg0,arg1));
+        }
+        static void BuiltinClassInit_TrModule(TrClass cls)
+        {
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrModule)self).__bool__());
+        }
+        static void BuiltinClassInit_TrNone(TrClass cls)
+        {
+        }
+        static void BuiltinClassInit_TrProperty(TrClass cls)
+        {
+        }
+        static void BuiltinClassInit_TrRef(TrClass cls)
+        {
+        }
+        static void BuiltinClassInit_TrSet(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrSet)self).__repr__());
+            cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((Traffy.Objects.TrSet)self).__iter__());
+        }
+        static void BuiltinClassInit_TrSlice(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrSlice)self).__repr__());
+        }
+        static void BuiltinClassInit_TrStaticMethod(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrStaticMethod)self).__repr__());
+            cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self,arg0,arg1) => ((Traffy.Objects.TrStaticMethod)self).__call__(arg0,arg1));
+        }
+        static void BuiltinClassInit_TrStr(TrClass cls)
+        {
+            cls[MagicNames.i___str__] = TrSharpFunc.FromFunc(cls.Name + ".__str__", (self) => ((Traffy.Objects.TrStr)self).__str__());
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrStr)self).__repr__());
+            cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self,arg0) => ((Traffy.Objects.TrStr)self).__add__(arg0));
+            cls[MagicNames.i___hash__] = TrSharpFunc.FromFunc(cls.Name + ".__hash__", (self) => ((Traffy.Objects.TrStr)self).__hash__());
+            cls[MagicNames.i___contains__] = TrSharpFunc.FromFunc(cls.Name + ".__contains__", (self,arg0) => ((Traffy.Objects.TrStr)self).__contains__(arg0));
+            cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((Traffy.Objects.TrStr)self).__iter__());
+            cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self,arg0) => ((Traffy.Objects.TrStr)self).__eq__(arg0));
+            cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self,arg0) => ((Traffy.Objects.TrStr)self).__ne__(arg0));
+            cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self,arg0) => ((Traffy.Objects.TrStr)self).__lt__(arg0));
+            cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self,arg0) => ((Traffy.Objects.TrStr)self).__le__(arg0));
+            cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self,arg0) => ((Traffy.Objects.TrStr)self).__gt__(arg0));
+            cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self,arg0) => ((Traffy.Objects.TrStr)self).__ge__(arg0));
+            cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((Traffy.Objects.TrStr)self).__bool__());
+        }
+        static void BuiltinClassInit_TrTraceback(TrClass cls)
+        {
+        }
+        static void BuiltinClassInit_TrTuple(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrTuple)self).__repr__());
+            cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((Traffy.Objects.TrTuple)self).__iter__());
+        }
+        static void BuiltinClassInit_TrUnionType(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrUnionType)self).__repr__());
+        }
+        static void BuiltinClassInit_TrFunc(TrClass cls)
+        {
+            cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((Traffy.Objects.TrFunc)self).__repr__());
+            cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self,arg0,arg1) => ((Traffy.Objects.TrFunc)self).__call__(arg0,arg1));
+        }
         static void BuiltinClassInit<T>(TrClass cls) where T : TrObject
         {
-            var ownership = typeof(T).GetInterfaceMethodSource();
-            if (ownership.Contains("__init__"))
-                cls[MagicNames.i___init__] = TrSharpFunc.FromFunc(cls.Name + ".__init__", (self, arg0, arg1) => ((T)self).__init__(arg0, arg1));
-            if (ownership.Contains("__str__"))
-                cls[MagicNames.i___str__] = TrSharpFunc.FromFunc(cls.Name + ".__str__", (self) => ((T)self).__str__());
-            if (ownership.Contains("__repr__"))
-                cls[MagicNames.i___repr__] = TrSharpFunc.FromFunc(cls.Name + ".__repr__", (self) => ((T)self).__repr__());
-            if (ownership.Contains("__next__"))
-                cls[MagicNames.i___next__] = TrSharpFunc.FromFunc(cls.Name + ".__next__", (self, arg0) => ((T)self).__next__(arg0));
-            if (ownership.Contains("__add__"))
-                cls[MagicNames.i___add__] = TrSharpFunc.FromFunc(cls.Name + ".__add__", (self, arg0) => ((T)self).__add__(arg0));
-            if (ownership.Contains("__sub__"))
-                cls[MagicNames.i___sub__] = TrSharpFunc.FromFunc(cls.Name + ".__sub__", (self, arg0) => ((T)self).__sub__(arg0));
-            if (ownership.Contains("__mul__"))
-                cls[MagicNames.i___mul__] = TrSharpFunc.FromFunc(cls.Name + ".__mul__", (self, arg0) => ((T)self).__mul__(arg0));
-            if (ownership.Contains("__matmul__"))
-                cls[MagicNames.i___matmul__] = TrSharpFunc.FromFunc(cls.Name + ".__matmul__", (self, arg0) => ((T)self).__matmul__(arg0));
-            if (ownership.Contains("__floordiv__"))
-                cls[MagicNames.i___floordiv__] = TrSharpFunc.FromFunc(cls.Name + ".__floordiv__", (self, arg0) => ((T)self).__floordiv__(arg0));
-            if (ownership.Contains("__truediv__"))
-                cls[MagicNames.i___truediv__] = TrSharpFunc.FromFunc(cls.Name + ".__truediv__", (self, arg0) => ((T)self).__truediv__(arg0));
-            if (ownership.Contains("__mod__"))
-                cls[MagicNames.i___mod__] = TrSharpFunc.FromFunc(cls.Name + ".__mod__", (self, arg0) => ((T)self).__mod__(arg0));
-            if (ownership.Contains("__pow__"))
-                cls[MagicNames.i___pow__] = TrSharpFunc.FromFunc(cls.Name + ".__pow__", (self, arg0) => ((T)self).__pow__(arg0));
-            if (ownership.Contains("__bitand__"))
-                cls[MagicNames.i___bitand__] = TrSharpFunc.FromFunc(cls.Name + ".__bitand__", (self, arg0) => ((T)self).__bitand__(arg0));
-            if (ownership.Contains("__bitor__"))
-                cls[MagicNames.i___bitor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitor__", (self, arg0) => ((T)self).__bitor__(arg0));
-            if (ownership.Contains("__bitxor__"))
-                cls[MagicNames.i___bitxor__] = TrSharpFunc.FromFunc(cls.Name + ".__bitxor__", (self, arg0) => ((T)self).__bitxor__(arg0));
-            if (ownership.Contains("__lshift__"))
-                cls[MagicNames.i___lshift__] = TrSharpFunc.FromFunc(cls.Name + ".__lshift__", (self, arg0) => ((T)self).__lshift__(arg0));
-            if (ownership.Contains("__rshift__"))
-                cls[MagicNames.i___rshift__] = TrSharpFunc.FromFunc(cls.Name + ".__rshift__", (self, arg0) => ((T)self).__rshift__(arg0));
-            if (ownership.Contains("__hash__"))
-                cls[MagicNames.i___hash__] = TrSharpFunc.FromFunc(cls.Name + ".__hash__", (self) => ((T)self).__hash__());
-            if (ownership.Contains("__call__"))
-                cls[MagicNames.i___call__] = TrSharpFunc.FromFunc(cls.Name + ".__call__", (self, arg0, arg1) => ((T)self).__call__(arg0, arg1));
-            if (ownership.Contains("__contains__"))
-                cls[MagicNames.i___contains__] = TrSharpFunc.FromFunc(cls.Name + ".__contains__", (self, arg0) => ((T)self).__contains__(arg0));
-            if (ownership.Contains("__round__"))
-                cls[MagicNames.i___round__] = TrSharpFunc.FromFunc(cls.Name + ".__round__", (self, arg0) => ((T)self).__round__(arg0));
-            if (ownership.Contains("__reversed__"))
-                cls[MagicNames.i___reversed__] = TrSharpFunc.FromFunc(cls.Name + ".__reversed__", (self) => ((T)self).__reversed__());
-            if (ownership.Contains("__getitem__"))
-                cls[MagicNames.i___getitem__] = TrSharpFunc.FromFunc(cls.Name + ".__getitem__", (self, arg0) => ((T)self).__getitem__(arg0));
-            if (ownership.Contains("__delitem__"))
-                cls[MagicNames.i___delitem__] = TrSharpFunc.FromFunc(cls.Name + ".__delitem__", (self, arg0) => ((T)self).__delitem__(arg0));
-            if (ownership.Contains("__setitem__"))
-                cls[MagicNames.i___setitem__] = TrSharpFunc.FromFunc(cls.Name + ".__setitem__", (self, arg0, arg1) => ((T)self).__setitem__(arg0, arg1));
-            if (ownership.Contains("__iter__"))
-                cls[MagicNames.i___iter__] = TrSharpFunc.FromFunc(cls.Name + ".__iter__", (self) => ((T)self).__iter__());
-            if (ownership.Contains("__await__"))
-                cls[MagicNames.i___await__] = TrSharpFunc.FromFunc(cls.Name + ".__await__", (self) => ((T)self).__await__());
-            if (ownership.Contains("__len__"))
-                cls[MagicNames.i___len__] = TrSharpFunc.FromFunc(cls.Name + ".__len__", (self) => ((T)self).__len__());
-            if (ownership.Contains("__eq__"))
-                cls[MagicNames.i___eq__] = TrSharpFunc.FromFunc(cls.Name + ".__eq__", (self, arg0) => ((T)self).__eq__(arg0));
-            if (ownership.Contains("__ne__"))
-                cls[MagicNames.i___ne__] = TrSharpFunc.FromFunc(cls.Name + ".__ne__", (self, arg0) => ((T)self).__ne__(arg0));
-            if (ownership.Contains("__lt__"))
-                cls[MagicNames.i___lt__] = TrSharpFunc.FromFunc(cls.Name + ".__lt__", (self, arg0) => ((T)self).__lt__(arg0));
-            if (ownership.Contains("__le__"))
-                cls[MagicNames.i___le__] = TrSharpFunc.FromFunc(cls.Name + ".__le__", (self, arg0) => ((T)self).__le__(arg0));
-            if (ownership.Contains("__gt__"))
-                cls[MagicNames.i___gt__] = TrSharpFunc.FromFunc(cls.Name + ".__gt__", (self, arg0) => ((T)self).__gt__(arg0));
-            if (ownership.Contains("__ge__"))
-                cls[MagicNames.i___ge__] = TrSharpFunc.FromFunc(cls.Name + ".__ge__", (self, arg0) => ((T)self).__ge__(arg0));
-            if (ownership.Contains("__neg__"))
-                cls[MagicNames.i___neg__] = TrSharpFunc.FromFunc(cls.Name + ".__neg__", (self) => ((T)self).__neg__());
-            if (ownership.Contains("__invert__"))
-                cls[MagicNames.i___invert__] = TrSharpFunc.FromFunc(cls.Name + ".__invert__", (self) => ((T)self).__invert__());
-            if (ownership.Contains("__pos__"))
-                cls[MagicNames.i___pos__] = TrSharpFunc.FromFunc(cls.Name + ".__pos__", (self) => ((T)self).__pos__());
-            if (ownership.Contains("__bool__"))
-                cls[MagicNames.i___bool__] = TrSharpFunc.FromFunc(cls.Name + ".__bool__", (self) => ((T)self).__bool__());
-            if (ownership.Contains("__abs__"))
-                cls[MagicNames.i___abs__] = TrSharpFunc.FromFunc(cls.Name + ".__abs__", (self) => ((T)self).__abs__());
-            if (ownership.Contains("__enter__"))
-                cls[MagicNames.i___enter__] = TrSharpFunc.FromFunc(cls.Name + ".__enter__", (self) => ((T)self).__enter__());
-            if (ownership.Contains("__exit__"))
-                cls[MagicNames.i___exit__] = TrSharpFunc.FromFunc(cls.Name + ".__exit__", (self, arg0, arg1, arg2) => ((T)self).__exit__(arg0, arg1, arg2));
+            if (typeof(T) == typeof(Traffy.Objects.TrBool))
+            {
+                BuiltinClassInit_TrBool(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrSharpFunc))
+            {
+                BuiltinClassInit_TrSharpFunc(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrByteArray))
+            {
+                BuiltinClassInit_TrByteArray(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrBytes))
+            {
+                BuiltinClassInit_TrBytes(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrClassMethod))
+            {
+                BuiltinClassInit_TrClassMethod(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrDict))
+            {
+                BuiltinClassInit_TrDict(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrFloat))
+            {
+                BuiltinClassInit_TrFloat(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrGenerator))
+            {
+                BuiltinClassInit_TrGenerator(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrInt))
+            {
+                BuiltinClassInit_TrInt(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrIter))
+            {
+                BuiltinClassInit_TrIter(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrList))
+            {
+                BuiltinClassInit_TrList(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrSharpMethod))
+            {
+                BuiltinClassInit_TrSharpMethod(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrModule))
+            {
+                BuiltinClassInit_TrModule(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrNone))
+            {
+                BuiltinClassInit_TrNone(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrProperty))
+            {
+                BuiltinClassInit_TrProperty(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrRef))
+            {
+                BuiltinClassInit_TrRef(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrSet))
+            {
+                BuiltinClassInit_TrSet(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrSlice))
+            {
+                BuiltinClassInit_TrSlice(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrStaticMethod))
+            {
+                BuiltinClassInit_TrStaticMethod(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrStr))
+            {
+                BuiltinClassInit_TrStr(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrTraceback))
+            {
+                BuiltinClassInit_TrTraceback(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrTuple))
+            {
+                BuiltinClassInit_TrTuple(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrUnionType))
+            {
+                BuiltinClassInit_TrUnionType(cls);
+                return;
+            }
+            if (typeof(T) == typeof(Traffy.Objects.TrFunc))
+            {
+                BuiltinClassInit_TrFunc(cls);
+                return;
+            }
+            throw new System.Exception("Unsupported type: " + typeof(T).FullName);
         }
         public void InitInlineCacheForMagicMethods()
         {

--- a/UnityPython.BackEnd/generated-src/Traffy.Objects/Object.cs
+++ b/UnityPython.BackEnd/generated-src/Traffy.Objects/Object.cs
@@ -1,172 +1,172 @@
-using System;
 using System.Collections.Generic;
+using System;
 namespace Traffy.Objects
 {
     public abstract partial class TrObject
     {
-        public virtual TrObject __init__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public virtual  TrObject __init__(BList<TrObject> args,Dictionary<TrObject,TrObject> kwargs)
         {
-            return TrObject.__init__(this, args, kwargs);
+            return TrObject.__init__(this,args,kwargs);
         }
-        public virtual String __str__()
+        public virtual  String __str__()
         {
             return TrObject.__str__(this);
         }
-        public virtual String __repr__()
+        public virtual  String __repr__()
         {
             return TrObject.__repr__(this);
         }
-        public virtual Boolean __next__(TrRef refval)
+        public virtual  Boolean __next__(TrRef refval)
         {
-            return TrObject.__next__(this, refval);
+            return TrObject.__next__(this,refval);
         }
-        public virtual TrObject __add__(TrObject a)
+        public virtual  TrObject __add__(TrObject a)
         {
-            return TrObject.__add__(this, a);
+            return TrObject.__add__(this,a);
         }
-        public virtual TrObject __sub__(TrObject a)
+        public virtual  TrObject __sub__(TrObject a)
         {
-            return TrObject.__sub__(this, a);
+            return TrObject.__sub__(this,a);
         }
-        public virtual TrObject __mul__(TrObject a)
+        public virtual  TrObject __mul__(TrObject a)
         {
-            return TrObject.__mul__(this, a);
+            return TrObject.__mul__(this,a);
         }
-        public virtual TrObject __matmul__(TrObject a)
+        public virtual  TrObject __matmul__(TrObject a)
         {
-            return TrObject.__matmul__(this, a);
+            return TrObject.__matmul__(this,a);
         }
-        public virtual TrObject __floordiv__(TrObject a)
+        public virtual  TrObject __floordiv__(TrObject a)
         {
-            return TrObject.__floordiv__(this, a);
+            return TrObject.__floordiv__(this,a);
         }
-        public virtual TrObject __truediv__(TrObject a)
+        public virtual  TrObject __truediv__(TrObject a)
         {
-            return TrObject.__truediv__(this, a);
+            return TrObject.__truediv__(this,a);
         }
-        public virtual TrObject __mod__(TrObject a)
+        public virtual  TrObject __mod__(TrObject a)
         {
-            return TrObject.__mod__(this, a);
+            return TrObject.__mod__(this,a);
         }
-        public virtual TrObject __pow__(TrObject a)
+        public virtual  TrObject __pow__(TrObject a)
         {
-            return TrObject.__pow__(this, a);
+            return TrObject.__pow__(this,a);
         }
-        public virtual TrObject __bitand__(TrObject a)
+        public virtual  TrObject __bitand__(TrObject a)
         {
-            return TrObject.__bitand__(this, a);
+            return TrObject.__bitand__(this,a);
         }
-        public virtual TrObject __bitor__(TrObject a)
+        public virtual  TrObject __bitor__(TrObject a)
         {
-            return TrObject.__bitor__(this, a);
+            return TrObject.__bitor__(this,a);
         }
-        public virtual TrObject __bitxor__(TrObject a)
+        public virtual  TrObject __bitxor__(TrObject a)
         {
-            return TrObject.__bitxor__(this, a);
+            return TrObject.__bitxor__(this,a);
         }
-        public virtual TrObject __lshift__(TrObject a)
+        public virtual  TrObject __lshift__(TrObject a)
         {
-            return TrObject.__lshift__(this, a);
+            return TrObject.__lshift__(this,a);
         }
-        public virtual TrObject __rshift__(TrObject a)
+        public virtual  TrObject __rshift__(TrObject a)
         {
-            return TrObject.__rshift__(this, a);
+            return TrObject.__rshift__(this,a);
         }
-        public virtual Int32 __hash__()
+        public virtual  Int32 __hash__()
         {
             return TrObject.__hash__(this);
         }
-        public virtual TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public virtual  TrObject __call__(BList<TrObject> args,Dictionary<TrObject,TrObject> kwargs)
         {
-            return TrObject.__call__(this, args, kwargs);
+            return TrObject.__call__(this,args,kwargs);
         }
-        public virtual Boolean __contains__(TrObject a)
+        public virtual  Boolean __contains__(TrObject a)
         {
-            return TrObject.__contains__(this, a);
+            return TrObject.__contains__(this,a);
         }
-        public virtual TrObject __round__(TrObject ndigits)
+        public virtual  TrObject __round__(TrObject ndigits)
         {
-            return TrObject.__round__(this, ndigits);
+            return TrObject.__round__(this,ndigits);
         }
-        public virtual TrObject __reversed__()
+        public virtual  TrObject __reversed__()
         {
             return TrObject.__reversed__(this);
         }
-        public virtual TrObject __getitem__(TrObject item)
+        public virtual  TrObject __getitem__(TrObject item)
         {
-            return TrObject.__getitem__(this, item);
+            return TrObject.__getitem__(this,item);
         }
-        public virtual void __delitem__(TrObject item)
+        public virtual  void __delitem__(TrObject item)
         {
-            TrObject.__delitem__(this, item);
+            TrObject.__delitem__(this,item);
         }
-        public virtual void __setitem__(TrObject key, TrObject value)
+        public virtual  void __setitem__(TrObject key,TrObject value)
         {
-            TrObject.__setitem__(this, key, value);
+            TrObject.__setitem__(this,key,value);
         }
-        public virtual IEnumerator<TrObject> __iter__()
+        public virtual  IEnumerator<TrObject> __iter__()
         {
             return TrObject.__iter__(this);
         }
-        public virtual Awaitable<TrObject> __await__()
+        public virtual  Awaitable<TrObject> __await__()
         {
             return TrObject.__await__(this);
         }
-        public virtual TrObject __len__()
+        public virtual  TrObject __len__()
         {
             return TrObject.__len__(this);
         }
-        public virtual Boolean __eq__(TrObject other)
+        public virtual  Boolean __eq__(TrObject other)
         {
-            return TrObject.__eq__(this, other);
+            return TrObject.__eq__(this,other);
         }
-        public virtual Boolean __ne__(TrObject other)
+        public virtual  Boolean __ne__(TrObject other)
         {
-            return TrObject.__ne__(this, other);
+            return TrObject.__ne__(this,other);
         }
-        public virtual Boolean __lt__(TrObject other)
+        public virtual  Boolean __lt__(TrObject other)
         {
-            return TrObject.__lt__(this, other);
+            return TrObject.__lt__(this,other);
         }
-        public virtual Boolean __le__(TrObject other)
+        public virtual  Boolean __le__(TrObject other)
         {
-            return TrObject.__le__(this, other);
+            return TrObject.__le__(this,other);
         }
-        public virtual Boolean __gt__(TrObject other)
+        public virtual  Boolean __gt__(TrObject other)
         {
-            return TrObject.__gt__(this, other);
+            return TrObject.__gt__(this,other);
         }
-        public virtual Boolean __ge__(TrObject other)
+        public virtual  Boolean __ge__(TrObject other)
         {
-            return TrObject.__ge__(this, other);
+            return TrObject.__ge__(this,other);
         }
-        public virtual TrObject __neg__()
+        public virtual  TrObject __neg__()
         {
             return TrObject.__neg__(this);
         }
-        public virtual TrObject __invert__()
+        public virtual  TrObject __invert__()
         {
             return TrObject.__invert__(this);
         }
-        public virtual TrObject __pos__()
+        public virtual  TrObject __pos__()
         {
             return TrObject.__pos__(this);
         }
-        public virtual Boolean __bool__()
+        public virtual  Boolean __bool__()
         {
             return TrObject.__bool__(this);
         }
-        public virtual TrObject __abs__()
+        public virtual  TrObject __abs__()
         {
             return TrObject.__abs__(this);
         }
-        public virtual TrObject __enter__()
+        public virtual  TrObject __enter__()
         {
             return TrObject.__enter__(this);
         }
-        public virtual TrObject __exit__(TrObject exc_type, TrObject exc_value, TrObject traceback)
+        public virtual  TrObject __exit__(TrObject exc_type,TrObject exc_value,TrObject traceback)
         {
-            return TrObject.__exit__(this, exc_type, exc_value, traceback);
+            return TrObject.__exit__(this,exc_type,exc_value,traceback);
         }
     }
 }

--- a/UnityPython.BackEnd/generated-src/Traffy.Objects/Object.cs
+++ b/UnityPython.BackEnd/generated-src/Traffy.Objects/Object.cs
@@ -1,172 +1,172 @@
-using System.Collections.Generic;
 using System;
-    namespace Traffy.Objects
+using System.Collections.Generic;
+namespace Traffy.Objects
+{
+    public abstract partial class TrObject
     {
-    public partial interface TrObject
-    {
-        TrObject __init__(BList<TrObject> args,Dictionary<TrObject,TrObject> kwargs)
+        public virtual TrObject __init__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
-            return TrObject.__init__(this,args,kwargs);
+            return TrObject.__init__(this, args, kwargs);
         }
-        String __str__()
+        public virtual String __str__()
         {
             return TrObject.__str__(this);
         }
-        String __repr__()
+        public virtual String __repr__()
         {
             return TrObject.__repr__(this);
         }
-        Boolean __next__(TrRef refval)
+        public virtual Boolean __next__(TrRef refval)
         {
-            return TrObject.__next__(this,refval);
+            return TrObject.__next__(this, refval);
         }
-        TrObject __add__(TrObject a)
+        public virtual TrObject __add__(TrObject a)
         {
-            return TrObject.__add__(this,a);
+            return TrObject.__add__(this, a);
         }
-        TrObject __sub__(TrObject a)
+        public virtual TrObject __sub__(TrObject a)
         {
-            return TrObject.__sub__(this,a);
+            return TrObject.__sub__(this, a);
         }
-        TrObject __mul__(TrObject a)
+        public virtual TrObject __mul__(TrObject a)
         {
-            return TrObject.__mul__(this,a);
+            return TrObject.__mul__(this, a);
         }
-        TrObject __matmul__(TrObject a)
+        public virtual TrObject __matmul__(TrObject a)
         {
-            return TrObject.__matmul__(this,a);
+            return TrObject.__matmul__(this, a);
         }
-        TrObject __floordiv__(TrObject a)
+        public virtual TrObject __floordiv__(TrObject a)
         {
-            return TrObject.__floordiv__(this,a);
+            return TrObject.__floordiv__(this, a);
         }
-        TrObject __truediv__(TrObject a)
+        public virtual TrObject __truediv__(TrObject a)
         {
-            return TrObject.__truediv__(this,a);
+            return TrObject.__truediv__(this, a);
         }
-        TrObject __mod__(TrObject a)
+        public virtual TrObject __mod__(TrObject a)
         {
-            return TrObject.__mod__(this,a);
+            return TrObject.__mod__(this, a);
         }
-        TrObject __pow__(TrObject a)
+        public virtual TrObject __pow__(TrObject a)
         {
-            return TrObject.__pow__(this,a);
+            return TrObject.__pow__(this, a);
         }
-        TrObject __bitand__(TrObject a)
+        public virtual TrObject __bitand__(TrObject a)
         {
-            return TrObject.__bitand__(this,a);
+            return TrObject.__bitand__(this, a);
         }
-        TrObject __bitor__(TrObject a)
+        public virtual TrObject __bitor__(TrObject a)
         {
-            return TrObject.__bitor__(this,a);
+            return TrObject.__bitor__(this, a);
         }
-        TrObject __bitxor__(TrObject a)
+        public virtual TrObject __bitxor__(TrObject a)
         {
-            return TrObject.__bitxor__(this,a);
+            return TrObject.__bitxor__(this, a);
         }
-        TrObject __lshift__(TrObject a)
+        public virtual TrObject __lshift__(TrObject a)
         {
-            return TrObject.__lshift__(this,a);
+            return TrObject.__lshift__(this, a);
         }
-        TrObject __rshift__(TrObject a)
+        public virtual TrObject __rshift__(TrObject a)
         {
-            return TrObject.__rshift__(this,a);
+            return TrObject.__rshift__(this, a);
         }
-        Int32 __hash__()
+        public virtual Int32 __hash__()
         {
             return TrObject.__hash__(this);
         }
-        TrObject __call__(BList<TrObject> args,Dictionary<TrObject,TrObject> kwargs)
+        public virtual TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
-            return TrObject.__call__(this,args,kwargs);
+            return TrObject.__call__(this, args, kwargs);
         }
-        Boolean __contains__(TrObject a)
+        public virtual Boolean __contains__(TrObject a)
         {
-            return TrObject.__contains__(this,a);
+            return TrObject.__contains__(this, a);
         }
-        TrObject __round__(TrObject ndigits)
+        public virtual TrObject __round__(TrObject ndigits)
         {
-            return TrObject.__round__(this,ndigits);
+            return TrObject.__round__(this, ndigits);
         }
-        TrObject __reversed__()
+        public virtual TrObject __reversed__()
         {
             return TrObject.__reversed__(this);
         }
-        TrObject __getitem__(TrObject item)
+        public virtual TrObject __getitem__(TrObject item)
         {
-            return TrObject.__getitem__(this,item);
+            return TrObject.__getitem__(this, item);
         }
-        void __delitem__(TrObject item)
+        public virtual void __delitem__(TrObject item)
         {
-            TrObject.__delitem__(this,item);
+            TrObject.__delitem__(this, item);
         }
-        void __setitem__(TrObject key,TrObject value)
+        public virtual void __setitem__(TrObject key, TrObject value)
         {
-            TrObject.__setitem__(this,key,value);
+            TrObject.__setitem__(this, key, value);
         }
-        IEnumerator<TrObject> __iter__()
+        public virtual IEnumerator<TrObject> __iter__()
         {
             return TrObject.__iter__(this);
         }
-        Awaitable<TrObject> __await__()
+        public virtual Awaitable<TrObject> __await__()
         {
             return TrObject.__await__(this);
         }
-        TrObject __len__()
+        public virtual TrObject __len__()
         {
             return TrObject.__len__(this);
         }
-        Boolean __eq__(TrObject other)
+        public virtual Boolean __eq__(TrObject other)
         {
-            return TrObject.__eq__(this,other);
+            return TrObject.__eq__(this, other);
         }
-        Boolean __ne__(TrObject other)
+        public virtual Boolean __ne__(TrObject other)
         {
-            return TrObject.__ne__(this,other);
+            return TrObject.__ne__(this, other);
         }
-        Boolean __lt__(TrObject other)
+        public virtual Boolean __lt__(TrObject other)
         {
-            return TrObject.__lt__(this,other);
+            return TrObject.__lt__(this, other);
         }
-        Boolean __le__(TrObject other)
+        public virtual Boolean __le__(TrObject other)
         {
-            return TrObject.__le__(this,other);
+            return TrObject.__le__(this, other);
         }
-        Boolean __gt__(TrObject other)
+        public virtual Boolean __gt__(TrObject other)
         {
-            return TrObject.__gt__(this,other);
+            return TrObject.__gt__(this, other);
         }
-        Boolean __ge__(TrObject other)
+        public virtual Boolean __ge__(TrObject other)
         {
-            return TrObject.__ge__(this,other);
+            return TrObject.__ge__(this, other);
         }
-        TrObject __neg__()
+        public virtual TrObject __neg__()
         {
             return TrObject.__neg__(this);
         }
-        TrObject __invert__()
+        public virtual TrObject __invert__()
         {
             return TrObject.__invert__(this);
         }
-        TrObject __pos__()
+        public virtual TrObject __pos__()
         {
             return TrObject.__pos__(this);
         }
-        Boolean __bool__()
+        public virtual Boolean __bool__()
         {
             return TrObject.__bool__(this);
         }
-        TrObject __abs__()
+        public virtual TrObject __abs__()
         {
             return TrObject.__abs__(this);
         }
-        TrObject __enter__()
+        public virtual TrObject __enter__()
         {
             return TrObject.__enter__(this);
         }
-        TrObject __exit__(TrObject exc_type,TrObject exc_value,TrObject traceback)
+        public virtual TrObject __exit__(TrObject exc_type, TrObject exc_value, TrObject traceback)
         {
-            return TrObject.__exit__(this,exc_type,exc_value,traceback);
+            return TrObject.__exit__(this, exc_type, exc_value, traceback);
         }
     }
 }

--- a/UnityPython.BackEnd/runtests.sh
+++ b/UnityPython.BackEnd/runtests.sh
@@ -1,2 +1,2 @@
 unitypython.exe tests --includesrc --recursive --outdir out
-dotnet run out -c Release
+dotnet run --project UnityPython.Tests.csproj -c Release out

--- a/UnityPython.BackEnd/runtests.sh
+++ b/UnityPython.BackEnd/runtests.sh
@@ -1,2 +1,2 @@
 unitypython.exe tests --includesrc --recursive --outdir out
-dotnet run out -c Release --framework net6
+dotnet run out -c Release

--- a/UnityPython.BackEnd/runtests.sh
+++ b/UnityPython.BackEnd/runtests.sh
@@ -1,2 +1,2 @@
 unitypython.exe tests --includesrc --recursive --outdir out
-dotnet run out -c Release
+dotnet run out -c Release --framework net6

--- a/UnityPython.BackEnd/src/CSharpFeatures/Fix.cs
+++ b/UnityPython.BackEnd/src/CSharpFeatures/Fix.cs
@@ -1,0 +1,4 @@
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/UnityPython.BackEnd/src/Serialization/SimpleJson.Typed.cs
+++ b/UnityPython.BackEnd/src/Serialization/SimpleJson.Typed.cs
@@ -74,7 +74,7 @@ namespace SimpleJSON
             var res = new List<(string, Type, Action<object, object>)>();
             foreach (var prop in typeobject.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
-                if (prop.CanWrite)
+                if (prop.CanWrite && prop.GetIndexParameters().Length == 0)
                 {
                     Action<object, object> setValue = prop.SetValue;
                     res.Add((prop.Name, prop.PropertyType, setValue));
@@ -221,7 +221,7 @@ namespace SimpleJSON
                             {
                                 args[0] = parse_key(kv.Key);
 #if DEBUG
-                                Console.WriteLine(node.Tag + " ." + kv.Key + " -> " + t_value.Name);
+                                Console.WriteLine("spec " + node.Tag + " ." + kv.Key + " -> " + t_value.Name);
 #endif
                                 args[1] = Deserialize(kv.Value, t_value, context);
                                 Add(dict, args);
@@ -234,7 +234,7 @@ namespace SimpleJSON
                         {
                                 var jattr = jobject[name_field];
 #if DEBUG
-                                Console.WriteLine(node.Tag + " ." + name_field + " -> " + t_field.Name);
+                                Console.WriteLine("real " + node.Tag + " ." + name_field + " -> " + t_field.Name);
 #endif
 
                             var value = Deserialize(jattr, t_field, context);
@@ -344,8 +344,11 @@ namespace SimpleJSON
                     concreteClasses = new Dictionary<string, Type>();
                     foreach (var t in typeobject.Assembly.GetTypes())
                     {
-                        if (t.IsClass && !t.IsAbstract)
+                        if (typeobject.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract && t.GetCustomAttribute<SerializableAttribute>() != null)
                         {
+#if DEBUG
+                            Console.WriteLine($"{t.Name} implements {typeobject.Name}");
+#endif
                             concreteClasses[t.Name] = t;
                         }
                     }

--- a/UnityPython.BackEnd/src/Traffy.BuiltinFunctions/IO.cs
+++ b/UnityPython.BackEnd/src/Traffy.BuiltinFunctions/IO.cs
@@ -43,7 +43,7 @@ namespace Traffy
             if (flush)
                 System.Console.Out.Flush();
 #else
-            Debug.Log(sb.ToString());
+            UnityEngine.Debug.Log(sb.ToString());
 #endif
             return MK.None();
         }

--- a/UnityPython.BackEnd/src/Traffy.Objects/Bool.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Bool.cs
@@ -22,10 +22,10 @@ namespace Traffy.Objects
     {
         public bool value;
 
-        bool TrObject.__bool__() => value;
+        public override bool __bool__() => value;
 
-        string TrObject.__repr__() => value ? "True" : "False";
-        object TrObject.Native => value;
+        public override string __repr__() => value ? "True" : "False";
+        public override object Native => value;
         internal static TrBool TrBool_True = new TrBool(true);
         internal static TrBool TrBool_False = new TrBool(false);
 
@@ -36,7 +36,9 @@ namespace Traffy.Objects
         }
 
         static TrClass CLASS = null;
-        TrClass TrObject.Class => CLASS;
+        public override TrClass Class => CLASS;
+
+        public override List<TrObject> __array__ => null;
 
         public static TrObject datanew(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Bool.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Bool.cs
@@ -18,6 +18,7 @@ namespace Traffy.Objects
     }
 
     [Serializable]
+    [Traffy.Annotations.PyBuiltin]
     public sealed partial class TrBool : TrObject
     {
         public bool value;

--- a/UnityPython.BackEnd/src/Traffy.Objects/BuiltinFunction.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/BuiltinFunction.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Traffy.Objects
 {
+    [Traffy.Annotations.PyBuiltin]
     public sealed class TrSharpFunc : TrObject
     {
         public string name;

--- a/UnityPython.BackEnd/src/Traffy.Objects/BuiltinFunction.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/BuiltinFunction.cs
@@ -9,11 +9,11 @@ namespace Traffy.Objects
     {
         public string name;
         [NotNull] public Func<BList<TrObject>, Dictionary<TrObject, TrObject>, TrObject> func;
-        string TrObject.__repr__() => $"<function {name}>";
-        bool TrObject.__bool__() => true;
+        public override string __repr__() => $"<function {name}>";
+        public override bool __bool__() => true;
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
-        List<TrObject> TrObject.__array__ => null;
+        public override TrClass Class => CLASS;
+        public override List<TrObject> __array__ => null;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -30,7 +30,7 @@ namespace Traffy.Objects
             Initialization.Prelude(CLASS);
         }
 
-        TrObject TrObject.__call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             try
             {

--- a/UnityPython.BackEnd/src/Traffy.Objects/ByteArray.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/ByteArray.cs
@@ -10,29 +10,29 @@ namespace Traffy.Objects
     public sealed class TrByteArray : TrObject
     {
         public FList<byte> contents;
-        object TrObject.Native => contents;
-        string TrObject.__repr__() => contents.Select(x => $"\\x{x:X}").Prepend("bytearray(b'").Append("')").By(String.Concat);
-        bool TrObject.__bool__() => contents.Count != 0;
-        List<TrObject> TrObject.__array__ => null;
+        public override object Native => contents;
+        public override string __repr__() => contents.Select(x => $"\\x{x:X}").Prepend("bytearray(b'").Append("')").By(String.Concat);
+        public override bool __bool__() => contents.Count != 0;
+        public override List<TrObject> __array__ => null;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        bool TrObject.__le__(TrObject other) =>
+        public override bool __le__(TrObject other) =>
             (other is TrBytes b)
             ? contents.SeqLtE<FList<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
             ? contents.SeqLtE<FList<byte>, FList<byte>, byte>(byteArray.contents)
             : throw new TypeError($"unsupported operand type(s) for <=: '{CLASS.Name}' and '{other.Class.Name}'");
 
-        bool TrObject.__lt__(TrObject other) =>
+        public override bool __lt__(TrObject other) =>
             (other is TrBytes b)
             ? contents.SeqLt<FList<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
             ? contents.SeqLt<FList<byte>, FList<byte>, byte>(byteArray.contents)
             : throw new TypeError($"unsupported operand type(s) for <: '{CLASS.Name}' and '{other.Class.Name}'");
 
-        bool TrObject.__gt__(TrObject other) =>
+        public override bool __gt__(TrObject other) =>
             (other is TrBytes b)
             ? contents.SeqGt<FList<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -40,7 +40,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for >: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        bool TrObject.__ge__(TrObject other) =>
+        public override bool __ge__(TrObject other) =>
             (other is TrBytes b)
             ? contents.SeqGtE<FList<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -48,7 +48,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for >=: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        bool TrObject.__ne__(TrObject other) =>
+        public override bool __ne__(TrObject other) =>
             (other is TrBytes b)
             ? contents.SeqNe<FList<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -56,7 +56,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for !=: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        bool TrObject.__eq__(TrObject other) =>
+        public override bool __eq__(TrObject other) =>
             (other is TrBytes b)
             ? contents.SeqEq<FList<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -81,7 +81,7 @@ namespace Traffy.Objects
             Initialization.Prelude(CLASS);
         }
 
-        TrObject TrObject.__add__(TrObject other)
+        public override TrObject __add__(TrObject other)
         {
             if (other is TrBytes b)
             {

--- a/UnityPython.BackEnd/src/Traffy.Objects/ByteArray.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/ByteArray.cs
@@ -7,6 +7,7 @@ using InlineHelper;
 namespace Traffy.Objects
 {
 
+    [Traffy.Annotations.PyBuiltin]
     public sealed class TrByteArray : TrObject
     {
         public FList<byte> contents;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Bytes.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Bytes.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
-
+using System.Linq;
 using InlineHelper;
 
 namespace Traffy.Objects
 {
     [Serializable]
-    public sealed class TrBytes : TrObject
+    public sealed class TrBytes : TrObject, IComparable<TrObject>
     {
         public byte[] contents;
         int IComparable<TrObject>.CompareTo(TrObject other)
@@ -29,10 +28,11 @@ namespace Traffy.Objects
         }
 
 
-        string TrObject.__repr__() => contents.Select(x => $"\\x{x:X}").Prepend("b'").Append("'").By(String.Concat);
-        bool TrObject.__bool__() => contents.Length != 0;
+        public override string __repr__() => contents.Select(x => $"\\x{x:X}").Prepend("b'").Append("'").By(String.Concat);
+        public override bool __bool__() => contents.Length != 0;
         public static TrClass CLASS;
-        TrClass TrObject.Class => CLASS;
+        public override TrClass Class => CLASS;
+        public override List<TrObject> __array__ => null;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -52,9 +52,9 @@ namespace Traffy.Objects
             Initialization.Prelude(CLASS);
         }
 
-        object TrObject.Native => contents;
+        public override object Native => contents;
 
-        TrObject TrObject.__add__(TrObject other)
+        public override TrObject __add__(TrObject other)
         {
             if (other is TrBytes b)
             {
@@ -65,21 +65,21 @@ namespace Traffy.Objects
         }
 
 
-        bool TrObject.__le__(TrObject other) =>
+        public override bool __le__(TrObject other) =>
             (other is TrBytes b)
             ? contents.Inline().SeqLtE<FArray<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
             ? contents.Inline().SeqLtE<FArray<byte>, FList<byte>, byte>(byteArray.contents)
             : throw new TypeError($"unsupported operand type(s) for <=: '{CLASS.Name}' and '{other.Class.Name}'");
 
-        bool TrObject.__lt__(TrObject other) =>
+        public override bool __lt__(TrObject other) =>
             (other is TrBytes b)
             ? contents.Inline().SeqLt<FArray<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
             ? contents.Inline().SeqLt<FArray<byte>, FList<byte>, byte>(byteArray.contents)
             : throw new TypeError($"unsupported operand type(s) for <: '{CLASS.Name}' and '{other.Class.Name}'");
 
-        bool TrObject.__gt__(TrObject other) =>
+        public override bool __gt__(TrObject other) =>
             (other is TrBytes b)
             ? contents.Inline().SeqGt<FArray<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -87,7 +87,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for >: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        bool TrObject.__ge__(TrObject other) =>
+        public override bool __ge__(TrObject other) =>
             (other is TrBytes b)
             ? contents.Inline().SeqGtE<FArray<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -95,7 +95,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for >=: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        bool TrObject.__ne__(TrObject other) =>
+        public override bool __ne__(TrObject other) =>
             (other is TrBytes b)
             ? contents.Inline().SeqNe<FArray<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -103,7 +103,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for !=: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        bool TrObject.__eq__(TrObject other) =>
+        public override bool __eq__(TrObject other) =>
             (other is TrBytes b)
             ? contents.Inline().SeqEq<FArray<byte>, FArray<byte>, byte>(b.contents)
             : (other is TrByteArray byteArray)
@@ -111,7 +111,7 @@ namespace Traffy.Objects
             : throw new TypeError($"unsupported operand type(s) for ==: '{CLASS.Name}' and '{other.Class.Name}'");
 
 
-        int TrObject.__hash__()
+        public override int __hash__()
         {
             return contents.Inline().ByteSequenceHash<FArray<byte>>(
                 Initialization.HashConfig.BYTE_HASH_SEED,

--- a/UnityPython.BackEnd/src/Traffy.Objects/Bytes.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Bytes.cs
@@ -6,6 +6,7 @@ using InlineHelper;
 namespace Traffy.Objects
 {
     [Serializable]
+    [Traffy.Annotations.PyBuiltin]
     public sealed class TrBytes : TrObject, IComparable<TrObject>
     {
         public byte[] contents;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Class.IC.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Class.IC.cs
@@ -87,15 +87,15 @@ namespace Traffy.Objects
             return false;
         }
 
-        public bool __getic__(PolyIC ic, out TrObject found) =>
+        public override bool __getic__(PolyIC ic, out TrObject found) =>
             ic.ICClass.ReadClass(this, out found);
-        public void __setic__(PolyIC ic, TrObject value) =>
+        public override void __setic__(PolyIC ic, TrObject value) =>
             __setic_refl__(ic.attribute, value);
 
-        public bool __getic_refl__(TrStr s, out TrObject found) =>
+        public override bool __getic_refl__(TrStr s, out TrObject found) =>
             PolyIC.ReadClass_refl(this, s, out found);
 
-        public void __setic_refl__(TrStr s, TrObject value) =>
+        public override void __setic_refl__(TrStr s, TrObject value) =>
             PolyIC.WriteClass_refl(this, s, value);
 
         public TrObject this[InternedString s]
@@ -104,13 +104,13 @@ namespace Traffy.Objects
             set => __setic_refl__(MK.IStr(s.Value), value);
         }
 
-        public TrObject this[string s]
+        public override TrObject this[string s]
         {
             get => __getic_refl__(MK.Str(s), out var value) ? value : null;
             set => __setic_refl__(MK.Str(s), value);
         }
 
-        public TrObject this[PolyIC ic]
+        public override TrObject this[PolyIC ic]
         {
             get => __getic__(ic, out var value) ? value : null;
             set => __setic_refl__(MK.IStr(ic.Name), value);

--- a/UnityPython.BackEnd/src/Traffy.Objects/Class.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Class.cs
@@ -39,7 +39,6 @@ namespace Traffy.Objects
 
     public sealed partial class TrClass : TrObject
     {
-        public bool IsClass => true;
         static IdComparer idComparer = new IdComparer();
         public static Dictionary<Type, TrClass> TypeDict = new Dictionary<Type, TrClass>();
         static TrClass MetaClass = null;
@@ -63,7 +62,7 @@ namespace Traffy.Objects
         // include itself
         public HashSet<TrClass> __subclasses = new HashSet<TrClass>(idComparer);
 
-        public List<TrObject> __array__ => null;
+        public override List<TrObject> __array__ => null;
 
         // does not contain those that are inherited from '__mro__'
         // values are never null
@@ -139,14 +138,14 @@ namespace Traffy.Objects
             throw new NotImplementedException("custom metaclasses not supported yet.");
         }
 
-        public TrClass Class { set; get; }
+        public override TrClass Class => MetaClass;
 
-        TrObject TrObject.__getitem__(TrObject item)
+        public override TrObject __getitem__(TrObject item)
         {
             return this;
         }
 
-        TrObject TrObject.__bitor__(Traffy.Objects.TrObject a)
+        public override TrObject __bitor__(Traffy.Objects.TrObject a)
         {
             if (a.IsNone())
             {
@@ -158,9 +157,9 @@ namespace Traffy.Objects
             }
             throw new TypeError($"unsupported operand type(s) for |: class '{this.Name}' and '{a.Class.Name}' object");
         }
-        public string __repr__() => Name;
+        public override string __repr__() => Name;
 
-        public TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             // XXX: should we support metaclasses other than 'type'?
             args.AddLeft(this);
@@ -251,7 +250,6 @@ namespace Traffy.Objects
                 __base = bases,
             };
             cls.InitInlineCacheForMagicMethods();
-            cls.Class = cls;
             return cls;
         }
 
@@ -325,7 +323,6 @@ namespace Traffy.Objects
         }
         public void SetupClass(Dictionary<TrObject, TrObject> kwargs)
         {
-            Class = MetaClass;
             __mro = C3_linearize(this);
             foreach (var cls in __mro)
             {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Class.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Class.cs
@@ -36,7 +36,6 @@ namespace Traffy.Objects
     }
 
 
-
     public sealed partial class TrClass : TrObject
     {
         static IdComparer idComparer = new IdComparer();

--- a/UnityPython.BackEnd/src/Traffy.Objects/Class.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Class.cs
@@ -375,7 +375,10 @@ namespace Traffy.Objects
                 var init_class = cls[ic__init_subclass];
                 if (init_class != null)
                 {
-                    init_class.Call(cls, this);
+                    var _args = new BList<TrObject>();
+                    _args.Add(cls);
+                    _args.Add(this);
+                    init_class.__call__(_args, null);
                     // XXX: different from CPython, we don't break here
                     // break;
                 }

--- a/UnityPython.BackEnd/src/Traffy.Objects/ClassMethod.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/ClassMethod.cs
@@ -8,8 +8,8 @@ namespace Traffy.Objects
     {
         public TrObject func;
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
-        List<TrObject> TrObject.__array__ => null;
+        public override TrClass Class => CLASS;
+        public override List<TrObject> __array__ => null;
 
         [PyBind]
         public TrObject __func__

--- a/UnityPython.BackEnd/src/Traffy.Objects/ClassMethod.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/ClassMethod.cs
@@ -4,6 +4,8 @@ using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+
+    [PyBuiltin]
     public sealed partial class TrClassMethod : TrObject
     {
         public TrObject func;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Dict.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Dict.cs
@@ -10,38 +10,38 @@ namespace Traffy.Objects
         public Dictionary<TrObject, TrObject> container;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
-        string TrObject.__repr__() => "{" + String.Join(", ", container.Select(kv => $"{kv.Key.__repr__()}: {kv.Value.__repr__()}")) + "}";
+        public override string __repr__() => "{" + String.Join(", ", container.Select(kv => $"{kv.Key.__repr__()}: {kv.Value.__repr__()}")) + "}";
 
-        bool TrObject.__bool__() => container.Count > 0;
+        public override bool __bool__() => container.Count > 0;
 
 
-        TrObject TrObject.__getitem__(TrObject key)
+        public override TrObject __getitem__(TrObject key)
         {
             return container.TryGetValue(key, out var value) ? value : throw new KeyError(key);
         }
 
 
-        void TrObject.__setitem__(TrObject key, TrObject value)
+        public override void __setitem__(TrObject key, TrObject value)
         {
             container[key] = value;
         }
 
 
-        void TrObject.__delitem__(TrObject key)
+        public override void __delitem__(TrObject key)
         {
             container.Remove(key);
         }
 
-        TrObject TrObject.__reversed__()
+        public override TrObject __reversed__()
         {
             throw new TypeError("'dict' object is not reversible");
         }
 
-        TrObject TrObject.__len__()
+        public override TrObject __len__()
         {
             return MK.Int(container.Count);
         }

--- a/UnityPython.BackEnd/src/Traffy.Objects/Dict.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Dict.cs
@@ -5,6 +5,7 @@ using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public sealed partial class TrDict : TrObject
     {
         public Dictionary<TrObject, TrObject> container;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Exceptions.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Exceptions.cs
@@ -14,11 +14,11 @@ namespace Traffy.Objects
         }
     }
 
-    public interface TrExceptionBase : TrUserObjectBase
+    public abstract class TrExceptionBase : TrUserObjectBase
     {
-        public Exception AsException();
-        public int IndexArgs { get; }
-        public TrTraceback traceback { get; set; }
+        public Exception AsException() => RTS.exc_tobare(this);
+        public abstract int IndexArgs { get; }
+        public TrTraceback traceback;
 
         public static TrObject GetCause(TrObject _exc)
         {
@@ -52,13 +52,23 @@ namespace Traffy.Objects
             return String.Join(", ", ((TrExceptionBase)self).args.Select(x => x.__str__()));
         }
 
-        string TrObject.__repr__() => TrException_repr(this);
+        public override string __repr__() => TrException_repr(this);
 
-        string TrObject.__str__() => TrException_str(this);
+        public override string __str__() => TrException_str(this);
 
-        public string GetStackTrace()
+        public virtual string GetStackTrace()
         {
             return $"Traceback (most recent call last):\n{traceback?.GetStackTrace()}\n{Class.Name}: {__str__()}";
+        }
+
+        public static implicit operator TrExceptionBase(Exception e)
+        {
+            return RTS.exc_frombare(e);
+        }
+
+        public static implicit operator Exception(TrExceptionBase e)
+        {
+            return e.AsException();
         }
     }
 
@@ -88,17 +98,14 @@ namespace Traffy.Objects
             return res;
         }
     }
-    public class TrBaseException : Exception, TrExceptionBase
+    public class TrBaseException : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
 
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        public List<TrObject> __array__ { get; set; } = new List<TrObject>(1);
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
 
         public TrBaseException() : base()
         {
@@ -111,7 +118,7 @@ namespace Traffy.Objects
 
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -136,27 +143,24 @@ namespace Traffy.Objects
         }
     }
 
-    public class TrException : Exception, TrExceptionBase
+    public class TrException : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
         public TrException() : base()
         {
             this.Base().args = new TrObject[0];
         }
-        public TrException(string msg) : base(msg)
+        public TrException(string msg)
         {
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -178,16 +182,13 @@ namespace Traffy.Objects
     }
 
     // fields: 'name', 'obj'
-    public class AttributeError : Exception, TrExceptionBase
+    public class AttributeError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(3);
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(3);
 
         static InlineCache.PolyIC CacheName = new InlineCache.PolyIC("name".ToIntern());
         static InlineCache.PolyIC CacheObj = new InlineCache.PolyIC("obj".ToIntern());
@@ -199,7 +200,7 @@ namespace Traffy.Objects
             this.Base()[CacheObj] = obj;
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
-        public AttributeError(TrObject obj, TrObject attr, string msg) : base(msg)
+        public AttributeError(TrObject obj, TrObject attr, string msg)
         {
             Init(obj, attr, msg);
         }
@@ -210,7 +211,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -231,17 +232,14 @@ namespace Traffy.Objects
         }
     }
     // fields: 'name'
-    public class NameError : Exception, TrExceptionBase
+    public class NameError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
         static InlineCache.PolyIC CacheName = new InlineCache.PolyIC("name".ToIntern());
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(2);
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(2);
 
         void _Init(TrObject name, string msg)
         {
@@ -249,7 +247,7 @@ namespace Traffy.Objects
             this.Base()[CacheName] = name;
         }
 
-        public NameError(string name, string msg) : base(msg)
+        public NameError(string name, string msg)
         {
             _Init(name.ToTr(), msg);
         }
@@ -260,7 +258,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -281,17 +279,14 @@ namespace Traffy.Objects
         }
     }
 
-    public class TypeError : Exception, TrExceptionBase
+    public class TypeError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public TypeError(string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public TypeError(string msg)
         {
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
@@ -302,7 +297,7 @@ namespace Traffy.Objects
 
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -325,17 +320,14 @@ namespace Traffy.Objects
     }
 
 
-    public class ValueError : Exception, TrExceptionBase
+    public class ValueError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public ValueError(string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public ValueError(string msg)
         {
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
@@ -345,7 +337,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -369,26 +361,23 @@ namespace Traffy.Objects
 
 
     // fields: 'value'
-    public class StopIteration : Exception, TrExceptionBase
+    public class StopIteration : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString()
         {
             return this.Base().__repr__();
         }
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
         static InlineCache.PolyIC CacheValue = new InlineCache.PolyIC("value".ToIntern());
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(2);
-        public StopIteration(TrObject value) : base()
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(2);
+        public StopIteration(TrObject value)
         {
             this.Base().args = new TrObject[] { value };
             this.Base()[CacheValue] = value;
         }
-        public StopIteration() : base()
+        public StopIteration()
         {
             this.Base().args = new TrObject[0];
             this.Base()[CacheValue] = RTS.object_none;
@@ -396,7 +385,7 @@ namespace Traffy.Objects
 
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -418,27 +407,24 @@ namespace Traffy.Objects
         }
     }
 
-    public class LookupError : Exception, TrExceptionBase
+    public class LookupError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public LookupError(string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public LookupError(string msg)
         {
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
-        public LookupError() : base()
+        public LookupError()
         {
             this.Base().args = new TrObject[0];
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -460,17 +446,14 @@ namespace Traffy.Objects
     }
 
 
-    public class KeyError : Exception, TrExceptionBase
+    public class KeyError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public KeyError(TrObject value) : base(value.__repr__())
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public KeyError(TrObject value)
         {
             this.Base().args = new TrObject[] { value };
         }
@@ -480,7 +463,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -503,17 +486,14 @@ namespace Traffy.Objects
         }
     }
 
-    public class IndexError : Exception, TrExceptionBase
+    public class IndexError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public IndexError(string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public IndexError(string msg)
         {
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
@@ -524,7 +504,7 @@ namespace Traffy.Objects
 
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -546,17 +526,14 @@ namespace Traffy.Objects
         }
     }
 
-    public class AssertionError : Exception, TrExceptionBase
+    public class AssertionError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public AssertionError(TrObject value) : base(value.__repr__())
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public AssertionError(TrObject value)
         {
             this.Base().args = new TrObject[] { value };
         }
@@ -566,7 +543,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -592,20 +569,17 @@ namespace Traffy.Objects
     // - 'msg': string
     // - 'name': string
     // - 'path': string
-    public class ImportError : Exception, TrExceptionBase
+    public class ImportError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
         static PolyIC CacheName = new PolyIC("name".ToIntern());
         static PolyIC CachePath = new PolyIC("path".ToIntern());
         static PolyIC CacheMsg = new PolyIC("msg".ToIntern());
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(4);
-        public ImportError(string name, TrObject path, string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(4);
+        public ImportError(string name, TrObject path, string msg)
         {
             var o_msg = MK.Str(msg);
             this.Base().args = new TrObject[] { o_msg };
@@ -625,7 +599,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -647,17 +621,14 @@ namespace Traffy.Objects
         }
     }
 
-    public class RuntimeError : Exception, TrExceptionBase
+    public class RuntimeError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public RuntimeError(string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public RuntimeError(string msg)
         {
             this.Base().args = new TrObject[] { MK.Str(msg) };
         }
@@ -667,7 +638,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -689,17 +660,14 @@ namespace Traffy.Objects
         }
     }
 
-    public class NotImplementError : Exception, TrExceptionBase
+    public class NotImplementError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
-        public NotImplementError(string msg) : base(msg)
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
+        public NotImplementError(string msg)
         {
 
             this.Base().args = new TrObject[] { MK.Str(msg) };
@@ -712,7 +680,7 @@ namespace Traffy.Objects
 
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -733,22 +701,19 @@ namespace Traffy.Objects
         }
     }
 
-    public class NativeError : Exception, TrExceptionBase
+    public class NativeError : TrExceptionBase
     {
-        public TrTraceback traceback { get; set; }
-        public Exception AsException() => this;
-        public override string StackTrace => ((TrExceptionBase)this).GetStackTrace();
         public override string ToString() => this.Base().__repr__();
         static int _IndexArgs = -1;
-        int TrExceptionBase.IndexArgs => _IndexArgs;
+        public override int IndexArgs => _IndexArgs;
 
         static int _IndexTypeName = -1;
         static int _IndexMsg = -1;
 
-        List<TrObject> TrObject.__array__ { get; } = new List<TrObject>(1);
+        public override List<TrObject> __array__ { get; } = new List<TrObject>(1);
         public Exception Error;
-        object TrObject.Native => Error;
-        bool TrObject.__eq__(TrObject other)
+        public override object Native => Error;
+        public override bool __eq__(TrObject other)
         {
             if (other is NativeError inner)
             {
@@ -756,7 +721,7 @@ namespace Traffy.Objects
             }
             return false;
         }
-        public NativeError(Exception native) : base(native.Message)
+        public NativeError(Exception native)
         {
             if (native is TrExceptionBase)
                 throw new Exception("native error should not be a traffy error");
@@ -767,7 +732,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -798,7 +763,7 @@ namespace Traffy.Objects
             // just report error
             throw new TypeError("cannot create native error manually");
         }
-        string TrExceptionBase.GetStackTrace()
+        public override string GetStackTrace()
         {
             return $"Traceback (most recent call last):\n{traceback?.GetStackTrace()}\n{Class.Name}: {this.Base().__str__()}\n{Error.StackTrace}";
         }

--- a/UnityPython.BackEnd/src/Traffy.Objects/Exceptions.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Exceptions.cs
@@ -723,7 +723,7 @@ namespace Traffy.Objects
         }
         public NativeError(Exception native)
         {
-            if (native is TrExceptionBase)
+            if (native is TrExceptionWrapper)
                 throw new Exception("native error should not be a traffy error");
             Error = native;
             this.Base().args = new TrObject[] { MK.Str(native.Message) };

--- a/UnityPython.BackEnd/src/Traffy.Objects/Exceptions.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Exceptions.cs
@@ -769,4 +769,16 @@ namespace Traffy.Objects
         }
     }
 
+    public class TrExceptionWrapper: Exception
+    {
+        public TrExceptionBase TrO;
+        public TrExceptionWrapper(TrExceptionBase trO): base (trO.args.Length > 0 ? trO.args[0].__str__() : "")
+        {
+            TrO = trO;
+        }
+
+        public override string ToString() => TrO.__repr__();
+        public override string StackTrace => TrO.GetStackTrace();
+    }
+
 }

--- a/UnityPython.BackEnd/src/Traffy.Objects/Float.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Float.cs
@@ -9,20 +9,20 @@ namespace Traffy.Objects
         public float value;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        object TrObject.Native => value;
-        List<TrObject> TrObject.__array__ => null;
+        public override object Native => value;
+        public override List<TrObject> __array__ => null;
 
-        TrObject TrObject.__round__(TrObject ndigits)
+        public override TrObject __round__(TrObject ndigits)
         {
             if (ndigits.IsNone())
                 return MK.Int(System.Convert.ToInt64(value));
             return MK.Float(Math.Round(value, ndigits.AsInt(), MidpointRounding.AwayFromZero));
         }
-        bool TrObject.__bool__() => value != 0.0f;
+        public override bool __bool__() => value != 0.0f;
 
-        string TrObject.__repr__() => value.ToString();
+        public override string __repr__() => value.ToString();
 
         public static TrObject datanew(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Float.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Float.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
     [Serializable]
+    [PyBuiltin]
     public sealed partial class TrFloat : TrObject
     {
         public float value;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Generator.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Generator.cs
@@ -20,9 +20,9 @@ namespace Traffy.Objects
         public TrObject Current => m_Generator.GetResult();
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
 
         public static TrObject datanew(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
@@ -64,11 +64,11 @@ namespace Traffy.Objects
             throw new NotSupportedException("cannot reset Traffy coroutines");
         }
 
-        Awaitable<TrObject> TrObject.__await__() => this.m_Generator;
-        IEnumerator<TrObject> TrObject.__iter__() => this;
+        public override Awaitable<TrObject> __await__() => this.m_Generator;
+        public override IEnumerator<TrObject> __iter__() => this;
 
         [MethodImpl(MethodImplOptionsCompat.Best)]
-        bool TrObject.__next__(TrRef refval)
+        public override bool __next__(TrRef refval)
         {
             m_Generator.m_Result = RTS.object_none;
             if (m_Generator.MoveNext())

--- a/UnityPython.BackEnd/src/Traffy.Objects/Generator.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Generator.cs
@@ -7,6 +7,7 @@ using Traffy.Annotations;
 namespace Traffy.Objects
 {
 
+    [PyBuiltin]
     public sealed partial class TrGenerator : TrObject, IEnumerator<TrObject>
     {
         // at the end of such generator, result is set.

--- a/UnityPython.BackEnd/src/Traffy.Objects/Int.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Int.cs
@@ -19,6 +19,7 @@ namespace Traffy.Objects
         }
     }
     [Serializable]
+    [PyBuiltin]
     public sealed partial class TrInt : TrObject
     {
         public Int64 value;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Int.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Int.cs
@@ -22,15 +22,17 @@ namespace Traffy.Objects
     public sealed partial class TrInt : TrObject
     {
         public Int64 value;
-        object TrObject.Native => value;
+        public override object Native => value;
 
-        string TrObject.__repr__() => value.ToString();
+        public override string __repr__() => value.ToString();
 
         // XXX: CPython behavior: check 'ndigit' should be int
-        TrObject TrObject.__round__(TrObject _) => this;
+        public override TrObject __round__(TrObject _) => this;
 
         public static TrClass CLASS;
-        TrClass TrObject.Class => CLASS;
+        public override TrClass Class => CLASS;
+
+        public override List<TrObject> __array__ => null;
 
 
         [PyBind]

--- a/UnityPython.BackEnd/src/Traffy.Objects/Iter.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Iter.cs
@@ -6,12 +6,11 @@ using Traffy.Annotations;
 namespace Traffy.Objects
 {
 
-    [Serializable]
     public sealed partial class TrIter : TrObject, IEnumerator<TrObject>
     {
         public IEnumerator<TrObject> iter;
-        public IEnumerator<TrObject> __iter__ => this;
-        public object Native => iter;
+        public override IEnumerator<TrObject> __iter__() => this;
+        public override object Native => iter;
 
         public TrIter(IEnumerator<TrObject> itr)
         {
@@ -19,11 +18,8 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS = null;
-        public TrClass Class => CLASS;
-
-        List<TrObject> TrObject.__array__ => null;
-
-        IEnumerator<TrObject> TrObject.__iter__() => this;
+        public override TrClass Class => CLASS;
+        public override List<TrObject> __array__ => null;
 
         public TrObject Current => iter.Current;
 
@@ -35,8 +31,7 @@ namespace Traffy.Objects
             return MK.Iter(obj.__iter__());
         }
 
-
-        bool TrObject.__next__(TrRef refval)
+        public override bool __next__(TrRef refval)
         {
             if (iter.MoveNext())
             {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Iter.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Iter.cs
@@ -6,6 +6,7 @@ using Traffy.Annotations;
 namespace Traffy.Objects
 {
 
+    [PyBuiltin]
     public sealed partial class TrIter : TrObject, IEnumerator<TrObject>
     {
         public IEnumerator<TrObject> iter;

--- a/UnityPython.BackEnd/src/Traffy.Objects/List.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/List.cs
@@ -6,6 +6,7 @@ using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public sealed partial class TrList : TrObject, IComparable<TrObject>
     {
         public List<TrObject> container;

--- a/UnityPython.BackEnd/src/Traffy.Objects/List.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/List.cs
@@ -6,14 +6,14 @@ using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
-    public sealed partial class TrList : TrObject
+    public sealed partial class TrList : TrObject, IComparable<TrObject>
     {
         public List<TrObject> container;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
         [PyBind(Name = "compare")]
         int IComparable<TrObject>.CompareTo(TrObject other)
@@ -58,18 +58,18 @@ namespace Traffy.Objects
             throw new TypeError($"{clsobj.AsClass.Name}.__new__() takes 1 or 2 positional argument(s) but {narg} were given");
         }
 
-        IEnumerator<TrObject> TrObject.__iter__()
+        public override IEnumerator<TrObject> __iter__()
         {
             return container.GetEnumerator();
         }
 
-        TrObject TrObject.__len__() => MK.Int(container.Count);
+        public override TrObject __len__() => MK.Int(container.Count);
 
-        string TrObject.__repr__() => "[" + String.Join(",", container.Select((i) => i.__str__())) + "]";
+        public override string __repr__() => "[" + String.Join(",", container.Select((i) => i.__str__())) + "]";
 
-        string TrObject.__str__() => this.AsObject().__repr__();
+        public override string __str__() => this.AsObject().__repr__();
 
-        bool TrObject.__eq__(Traffy.Objects.TrObject other)
+        public override bool __eq__(Traffy.Objects.TrObject other)
         {
             if (other is TrList lst)
             {
@@ -78,7 +78,7 @@ namespace Traffy.Objects
             return false;
         }
 
-        bool TrObject.__ne__(Traffy.Objects.TrObject other)
+        public override bool __ne__(Traffy.Objects.TrObject other)
         {
             if (other is TrList lst)
             {
@@ -87,7 +87,7 @@ namespace Traffy.Objects
             return true;
         }
 
-        bool TrObject.__gt__(Traffy.Objects.TrObject other)
+        public override bool __gt__(Traffy.Objects.TrObject other)
         {
             if (other is TrList lst)
             {
@@ -96,7 +96,7 @@ namespace Traffy.Objects
             throw new TypeError($"'>' not supported between instances of '{Class.Name}' and '" + other.Class.Name + "'");
         }
 
-        bool TrObject.__ge__(Traffy.Objects.TrObject other)
+        public override bool __ge__(Traffy.Objects.TrObject other)
         {
             if (other is TrList lst)
             {
@@ -105,7 +105,7 @@ namespace Traffy.Objects
             throw new TypeError($"'>=' not supported between instances of '{Class.Name}' and '" + other.Class.Name + "'");
         }
 
-        bool TrObject.__lt__(Traffy.Objects.TrObject other)
+        public override bool __lt__(Traffy.Objects.TrObject other)
         {
             if (other is TrList lst)
             {
@@ -114,7 +114,7 @@ namespace Traffy.Objects
             throw new TypeError($"'<' not supported between instances of '{Class.Name}' and '" + other.Class.Name + "'");
         }
 
-        bool TrObject.__le__(Traffy.Objects.TrObject other)
+        public override bool __le__(Traffy.Objects.TrObject other)
         {
             if (other is TrList lst)
             {
@@ -129,7 +129,7 @@ namespace Traffy.Objects
             return MK.List(container.Copy());
         }
 
-        TrObject TrObject.__getitem__(TrObject item)
+        public override TrObject __getitem__(TrObject item)
         {
             switch (item)
             {
@@ -157,7 +157,7 @@ namespace Traffy.Objects
             }
         }
 
-        void TrObject.__setitem__(TrObject item, TrObject value)
+        public override void __setitem__(TrObject item, TrObject value)
         {
             switch (item)
             {
@@ -201,7 +201,7 @@ namespace Traffy.Objects
             }
         }
 
-        void TrObject.__delitem__(Traffy.Objects.TrObject item)
+        public override void __delitem__(Traffy.Objects.TrObject item)
         {
             switch (item)
             {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Method.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Method.cs
@@ -4,6 +4,7 @@ using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public partial class TrSharpMethod : TrObject
     {
         public TrObject func;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Method.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Method.cs
@@ -24,11 +24,11 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
-        string TrObject.__repr__() => $"<bound method {func.__repr__()} at {self.__repr__()}>";
+        public override string __repr__() => $"<bound method {func.__repr__()} at {self.__repr__()}>";
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -48,7 +48,7 @@ namespace Traffy.Objects
             Initialization.Prelude(CLASS);
         }
 
-        public TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             args.AddLeft(self);
             var o = func.__call__(args, kwargs);

--- a/UnityPython.BackEnd/src/Traffy.Objects/Module.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Module.cs
@@ -31,19 +31,17 @@ namespace Traffy.Objects
         public Dictionary<TrObject, TrObject> Namespace = RTS.baredict_create();
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
-        bool TrObject.__bool__() => true;
-        TrObject TrObject.__getitem__(TrObject item) => throw new TypeError("'module' object is not subscriptable");
-        void TrObject.__setitem__(TrObject key, TrObject value) => throw new TypeError("'module' object is not subscriptable");
-        bool TrObject.__getic__(Traffy.InlineCache.PolyIC ic, out Traffy.Objects.TrObject found) =>
+        public override bool __bool__() => true;
+        public override bool __getic__(Traffy.InlineCache.PolyIC ic, out Traffy.Objects.TrObject found) =>
             _read_module(ic.attribute, out found) || CLASS.__getic__(ic, out found);
-        void TrObject.__setic__(Traffy.InlineCache.PolyIC ic, Traffy.Objects.TrObject value) => _write_module(ic.attribute, value);
-        bool TrObject.__getic_refl__(Traffy.Objects.TrStr s, out Traffy.Objects.TrObject found) =>
+        public override void __setic__(Traffy.InlineCache.PolyIC ic, Traffy.Objects.TrObject value) => _write_module(ic.attribute, value);
+        public override bool __getic_refl__(Traffy.Objects.TrStr s, out Traffy.Objects.TrObject found) =>
             _read_module(s, out found) || CLASS.__getic_refl__(s, out found);
-        void TrObject.__setic_refl__(TrStr s, TrObject value) => _write_module(s, value);
+        public override void __setic_refl__(TrStr s, TrObject value) => _write_module(s, value);
 
         public bool _read_module(TrStr name, out TrObject found)
         {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Module.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Module.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public partial class TrModule : TrObject
     {
 

--- a/UnityPython.BackEnd/src/Traffy.Objects/None.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/None.cs
@@ -8,12 +8,10 @@ namespace Traffy.Objects
     public partial class TrNone : TrObject
     {
 
-        List<TrObject> TrObject.__array__ => null;
-
-        object TrObject.Native => this;
+        public override List<TrObject> __array__ => null;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
         public static TrNone Unique = new TrNone();
         public static bool unique_set = false;
 

--- a/UnityPython.BackEnd/src/Traffy.Objects/None.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/None.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
     [Serializable]
+    [PyBuiltin]
     public partial class TrNone : TrObject
     {
 

--- a/UnityPython.BackEnd/src/Traffy.Objects/Object.Common.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Object.Common.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Traffy.Objects
 {
-    public partial interface TrObject
+    public abstract partial class TrObject
     {
         public static int ObjectSequenceHash<TList>(TList xs, int seed, int primSeed) where TList : IList<TrObject>
         {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Object.IC.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Object.IC.cs
@@ -6,29 +6,29 @@ using Traffy.InlineCache;
 
 namespace Traffy.Objects
 {
-    public partial interface TrObject
+    public abstract partial class TrObject
     {
 
-        public TrObject this[PolyIC ic]
+        public virtual TrObject this[PolyIC ic]
         {
             get => __getic__(ic, out var ob) ? ob : null;
             set => __setic__(ic, value);
         }
-        public TrObject this[string s]
+        public virtual TrObject this[string s]
         {
             get => __getic_refl__(MK.Str(s), out var ob) ? ob : null;
             set => __setic_refl__(MK.Str(s), value);
         }
 
-        public bool __getic__(PolyIC ic, out TrObject found) =>
+        public virtual bool __getic__(PolyIC ic, out TrObject found) =>
             ic.ICInstance.ReadInst(this, out found);
-        public void __setic__(PolyIC ic, TrObject value) =>
+        public virtual void __setic__(PolyIC ic, TrObject value) =>
             ic.ICInstance.WriteInst(this, value);
 
-        public bool __getic_refl__(TrStr s, out TrObject found) =>
+        public virtual bool __getic_refl__(TrStr s, out TrObject found) =>
             PolyIC.ReadInst_refl(this, s, out found);
 
-        public void __setic_refl__(TrStr s, TrObject value) =>
+        public virtual void __setic_refl__(TrStr s, TrObject value) =>
             PolyIC.WriteInst_refl(this, s, value);
 
 

--- a/UnityPython.BackEnd/src/Traffy.Objects/Object.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Object.cs
@@ -29,7 +29,7 @@ namespace Traffy.Objects
         }
     }
 
-    public partial interface TrObject : IEquatable<TrObject>, IComparable<TrObject>
+    public abstract partial class TrObject : IEquatable<TrObject>, IComparable<TrObject>
     {
         public static TrObject[] EmptyObjectArray = new TrObject[0];
 
@@ -46,10 +46,9 @@ namespace Traffy.Objects
 
         // if the object is a class, cast it.
         public TrClass AsClass => (TrClass)this;
-        public bool IsClass => false;
-        public List<TrObject> __array__ => null;
-        public object Native => this;
-        public TrClass Class { get; }
+        public abstract List<TrObject> __array__ { get; }
+        public virtual object Native => this;
+        public abstract TrClass Class { get; }
         Exception unsupported(string op) =>
             throw new TypeError($"{Class.Name} has no attribute '{op}'");
 
@@ -332,7 +331,9 @@ namespace Traffy.Objects
     public class TrRawObject : TrUserObjectBase
     {
         public static TrClass CLASS;
-        TrClass TrObject.Class => CLASS;
+        public override TrClass Class => CLASS;
+
+        public override List<TrObject> __array__ => null;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -366,9 +367,9 @@ namespace Traffy.Objects
     public class TrUserObject : TrUserObjectBase
     {
         public TrClass CLASS;
-        TrClass TrObject.Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        public List<TrObject> __array__ { get; } = new List<TrObject>();
+        public override List<TrObject> __array__ { get; } = new List<TrObject>();
         public TrUserObject(TrClass cls)
         {
             CLASS = cls;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Property.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Property.cs
@@ -4,6 +4,7 @@ using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public partial class TrProperty : TrObject
     {
         TrObject _getter;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Property.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Property.cs
@@ -8,10 +8,10 @@ namespace Traffy.Objects
     {
         TrObject _getter;
         TrObject _setter = null;
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
         TrObject bind_setter(TrObject o)
         {
             _setter = o;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Ref.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Ref.cs
@@ -8,12 +8,10 @@ namespace Traffy.Objects
     {
         public TrObject value;
         static string s_attrValue = String.Intern("value");
-        object TrObject.Native => this;
-
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -53,8 +51,8 @@ namespace Traffy.Objects
             throw new AttributeError(this, s, $"'{CLASS.Name}' object has no attribute '" + s.value + "'");
         }
 
-        bool TrObject.__getic_refl__(Traffy.Objects.TrStr s, out Traffy.Objects.TrObject found) => _slow_read(s, out found);
-        bool TrObject.__getic__(Traffy.InlineCache.PolyIC ic, out Traffy.Objects.TrObject found)
+        public override bool __getic_refl__(Traffy.Objects.TrStr s, out Traffy.Objects.TrObject found) => _slow_read(s, out found);
+        public override bool __getic__(Traffy.InlineCache.PolyIC ic, out Traffy.Objects.TrObject found)
         {
             if (object.ReferenceEquals(ic.attribute.value, s_attrValue))
             {
@@ -70,8 +68,8 @@ namespace Traffy.Objects
         }
 
 
-        void TrObject.__setic_refl__(Traffy.Objects.TrStr s, Traffy.Objects.TrObject value) => _slow_write(s, value);
-        void TrObject.__setic__(Traffy.InlineCache.PolyIC ic, Traffy.Objects.TrObject s_value)
+        public override void __setic_refl__(Traffy.Objects.TrStr s, Traffy.Objects.TrObject value) => _slow_write(s, value);
+        public override void __setic__(Traffy.InlineCache.PolyIC ic, Traffy.Objects.TrObject s_value)
         {
             TrStr attr = ic.attribute;
             if (object.ReferenceEquals(attr.value, s_attrValue))

--- a/UnityPython.BackEnd/src/Traffy.Objects/Ref.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Ref.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public partial class TrRef : TrObject
     {
         public TrObject value;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Set.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Set.cs
@@ -8,12 +8,12 @@ namespace Traffy.Objects
         public HashSet<TrObject> container;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
-        IEnumerator<TrObject> TrObject.__iter__() => container.GetEnumerator();
+        public override List<TrObject> __array__ => null;
+        public override IEnumerator<TrObject> __iter__() => container.GetEnumerator();
 
-        string TrObject.__repr__() => "{" + string.Join(", ", container.Select(x => x.__repr__())) + "}";
+        public override string __repr__() => "{" + string.Join(", ", container.Select(x => x.__repr__())) + "}";
 
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]

--- a/UnityPython.BackEnd/src/Traffy.Objects/Set.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Set.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public partial class TrSet : TrObject
     {
         public HashSet<TrObject> container;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Slice.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Slice.cs
@@ -11,11 +11,11 @@ namespace Traffy.Objects
         public TrObject step;
 
         public static TrClass CLASS;
-        TrClass TrObject.Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
-        string TrObject.__repr__() => $"slice({start.__repr__()}:{stop.__repr__()}:{step.__repr__()})";
+        public override string __repr__() => $"slice({start.__repr__()}:{stop.__repr__()}:{step.__repr__()})";
 
         public static TrObject datanew(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {

--- a/UnityPython.BackEnd/src/Traffy.Objects/Slice.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Slice.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
     [Serializable]
+    [PyBuiltin]
     public class TrSlice : TrObject
     {
         public TrObject start;

--- a/UnityPython.BackEnd/src/Traffy.Objects/StaticMethod.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/StaticMethod.cs
@@ -7,12 +7,12 @@ namespace Traffy.Objects
     {
         public TrObject func;
 
-        string TrObject.__repr__() => $"<staticmethod {func.__repr__()}>";
+        public override string __repr__() => $"<staticmethod {func.__repr__()}>";
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()
@@ -32,7 +32,7 @@ namespace Traffy.Objects
             Initialization.Prelude(CLASS);
         }
 
-        TrObject TrObject.__call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             return func.__call__(args, kwargs);
         }

--- a/UnityPython.BackEnd/src/Traffy.Objects/StaticMethod.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/StaticMethod.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
+    [PyBuiltin]
     public class TrStaticMethod : TrObject
     {
         public TrObject func;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Str.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Str.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using InlineHelper;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
@@ -14,6 +15,7 @@ namespace Traffy.Objects
     }
 
     [Serializable]
+    [PyBuiltin]
     public partial class TrStr : TrObject, IComparable<TrObject>
     {
         public string value;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Str.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Str.cs
@@ -14,13 +14,13 @@ namespace Traffy.Objects
     }
 
     [Serializable]
-    public partial class TrStr : TrObject
+    public partial class TrStr : TrObject, IComparable<TrObject>
     {
         public string value;
         public bool isInterned = false;
-
         int IComparable<TrObject>.CompareTo(TrObject other)
         {
+            // TODO: check if this is called
             if (other is TrStr s)
             {
                 return value.CompareTo(s.value);
@@ -28,12 +28,11 @@ namespace Traffy.Objects
             throw new TypeError($"unsupported comparison for '{CLASS.Name}' and '{other.Class.Name}'");
         }
 
-        string TrObject.__repr__() => value.Escape();
-        string TrObject.__str__() => value;
-        bool TrObject.__bool__() => value.Length != 0;
-        List<TrObject> TrObject.__array__ => null;
-
-        IEnumerator<TrObject> TrObject.__iter__()
+        public override string __repr__() => value.Escape();
+        public override string __str__() => value;
+        public override bool __bool__() => value.Length != 0;
+        public override List<TrObject> __array__ => null;
+        public override IEnumerator<TrObject> __iter__()
         {
             for(int i = 0; i < value.Length; i++)
             {
@@ -42,7 +41,7 @@ namespace Traffy.Objects
         }
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
         public TrStr Interned() => isInterned ? this : MK.IStr(value);
         public InternedString GetInternedString() => InternedString.Unsafe(Interned().value);
 
@@ -50,11 +49,11 @@ namespace Traffy.Objects
             InternedString.Unsafe(this.value) :
             InternedString.FromString(value);
 
-        int TrObject.__hash__() => value.GetHashCode();
+        public override int __hash__() => value.GetHashCode();
 
-        bool TrObject.__contains__(TrObject other) => value.Contains(other.AsStr());
+        public override bool __contains__(TrObject other) => value.Contains(other.AsStr());
 
-        bool TrObject.__le__(TrObject other)
+        public override bool __le__(TrObject other)
         {
             if (!(other is TrStr b))
             {
@@ -62,7 +61,7 @@ namespace Traffy.Objects
             }
             return value.Inline().SeqLtE<FString, FString, char>(b.value, out var _);
         }
-        bool TrObject.__lt__(TrObject other)
+        public override bool __lt__(TrObject other)
         {
             if (!(other is TrStr b))
             {
@@ -71,7 +70,7 @@ namespace Traffy.Objects
             return value.Inline().SeqLt<FString, FString, char>(b.value);
         }
 
-        bool TrObject.__gt__(TrObject other)
+        public override bool __gt__(TrObject other)
         {
             if (!(other is TrStr b))
             {
@@ -81,7 +80,7 @@ namespace Traffy.Objects
         }
 
 
-        bool TrObject.__ge__(TrObject other)
+        public override bool __ge__(TrObject other)
         {
             if (!(other is TrStr b))
             {
@@ -91,7 +90,7 @@ namespace Traffy.Objects
         }
 
 
-        bool TrObject.__ne__(TrObject other)
+        public override bool __ne__(TrObject other)
         {
             if (!(other is TrStr b))
             {
@@ -102,7 +101,7 @@ namespace Traffy.Objects
             return value != b.value;
         }
 
-        bool TrObject.__eq__(TrObject other)
+        public override bool __eq__(TrObject other)
         {
             if (!(other is TrStr b))
             {
@@ -131,9 +130,9 @@ namespace Traffy.Objects
             Initialization.Prelude(CLASS);
         }
 
-        object TrObject.Native => value;
+        public override object Native => value;
 
-        TrObject TrObject.__add__(TrObject other)
+        public override TrObject __add__(TrObject other)
         {
             if (other is TrStr s)
                 return MK.Str(value + s.value);

--- a/UnityPython.BackEnd/src/Traffy.Objects/Traceback.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Traceback.cs
@@ -32,6 +32,7 @@ namespace Traffy.Objects
         }
     }
 
+    [Traffy.Annotations.PyBuiltin]
     public class TrTraceback : TrObject
     {
         public List<FrameRecord> frameRecords = new List<FrameRecord>();

--- a/UnityPython.BackEnd/src/Traffy.Objects/Traceback.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Traceback.cs
@@ -59,10 +59,10 @@ namespace Traffy.Objects
             };
             frameRecords.Add(record);
         }
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
         static void _Init()

--- a/UnityPython.BackEnd/src/Traffy.Objects/Tuple.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Tuple.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
@@ -13,6 +14,7 @@ namespace Traffy.Objects
     }
 
     [Serializable]
+    [PyBuiltin]
     public partial class TrTuple : TrObject
     {
         public TrObject[] elts;

--- a/UnityPython.BackEnd/src/Traffy.Objects/Tuple.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/Tuple.cs
@@ -18,10 +18,10 @@ namespace Traffy.Objects
         public TrObject[] elts;
 
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
-        string TrObject.__repr__() =>
+        public override List<TrObject> __array__ => null;
+        public override string __repr__() =>
             elts.Length == 1 ? $"({elts[0].__repr__()},)" : "(" + String.Join(", ", elts.Select(x => x.__repr__())) + ")";
 
         [Traffy.Annotations.Mark(Initialization.TokenClassInit)]
@@ -34,7 +34,7 @@ namespace Traffy.Objects
             TrClass.TypeDict[typeof(TrTuple)] = CLASS;
         }
 
-        IEnumerator<TrObject> TrObject.__iter__()
+        public override IEnumerator<TrObject> __iter__()
         {
             return elts.AsEnumerable().GetEnumerator();
         }

--- a/UnityPython.BackEnd/src/Traffy.Objects/UnionType.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/UnionType.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
 
+    [PyBuiltin]
     public partial class TrUnionType : TrObject
     {
         public TrClass left;

--- a/UnityPython.BackEnd/src/Traffy.Objects/UnionType.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/UnionType.cs
@@ -5,16 +5,15 @@ using System.Linq;
 namespace Traffy.Objects
 {
 
-    [Serializable]
     public partial class TrUnionType : TrObject
     {
         public TrClass left;
         public TrClass right;
         public static TrClass CLASS;
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        List<TrObject> TrObject.__array__ => null;
-        string TrObject.__repr__() => left.__repr__() + "|" + right.__repr__();
+        public override List<TrObject> __array__ => null;
+        public override string __repr__() => left.__repr__() + "|" + right.__repr__();
 
         public TrUnionType(TrClass left, TrClass right)
         {

--- a/UnityPython.BackEnd/src/Traffy.Objects/UserFunc.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/UserFunc.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using Traffy.Annotations;
 
 namespace Traffy.Objects
 {
     // runtime
+    [PyBuiltin]
     public sealed class TrFunc : TrObject
     {
         public Variable[] freevars;

--- a/UnityPython.BackEnd/src/Traffy.Objects/UserFunc.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/UserFunc.cs
@@ -7,19 +7,26 @@ using System.Runtime.Serialization;
 namespace Traffy.Objects
 {
     // runtime
-    public record TrFunc(
-        Variable[] freevars,
-        Dictionary<TrObject, TrObject> globals,
-        (int slot, TrObject value)[] default_args,
-        TrFuncPointer fptr
-     ) : TrObject
+    public sealed class TrFunc : TrObject
     {
+        public Variable[] freevars;
+        public Dictionary<TrObject, TrObject> globals;
+        public (int slot, TrObject value)[] default_args;
+        public TrFuncPointer fptr;
+
+        public TrFunc(Variable[] freevars, Dictionary<TrObject, TrObject> globals, (int slot, TrObject value)[] default_args, TrFuncPointer fptr)
+        {
+            this.fptr = fptr;
+            this.freevars = freevars;
+            this.globals = globals;
+            this.default_args = default_args;
+        }
 
         public static TrClass CLASS;
 
-        public TrClass Class => CLASS;
+        public override TrClass Class => CLASS;
 
-        string TrObject.__repr__()
+        public override string __repr__()
         {
             return $"<function {fptr.metadata.codename}>";
         }
@@ -49,9 +56,9 @@ namespace Traffy.Objects
         }
         TrObject AsObject => this;
 
-        List<TrObject> TrObject.__array__ => null;
+        public override List<TrObject> __array__ => null;
 
-        TrObject TrObject.__call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             return Execute(args, kwargs, null);
         }

--- a/UnityPython.BackEnd/src/Traffy.Objects/UserObject.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/UserObject.cs
@@ -2,30 +2,30 @@ using System.Collections.Generic;
 using System;
 namespace Traffy.Objects
 {
-    public interface TrUserObjectBase: TrObject
+    public abstract class TrUserObjectBase: TrObject
     {
-        TrObject TrObject.__init__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __init__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             var self_init = this[Class.ic__init];
             if ((object)self_init == null)
                 return TrObject.__init__(this, args, kwargs);
             return self_init.__call__(args, kwargs);
         }
-        String TrObject.__str__()
+        public override string __str__()
         {
             var self_str = this[Class.ic__str];
             if ((object)self_str == null)
                 return TrObject.__str__(this);
             return self_str.Call().AsStr();
         }
-        String TrObject.__repr__()
+        public override String __repr__()
         {
             var self_repr = this[Class.ic__repr];
             if ((object)self_repr == null)
                 return TrObject.__repr__(this);
             return self_repr.Call().AsStr();
         }
-        Boolean TrObject.__next__(TrRef refval)
+        public override Boolean __next__(TrRef refval)
         {
             var self_next = this[Class.ic__next];
             if ((object)self_next == null)
@@ -33,126 +33,126 @@ namespace Traffy.Objects
             return self_next.Call(refval).AsBool();
         }
 
-        TrObject TrObject.__add__(TrObject a)
+        public override TrObject __add__(TrObject a)
         {
             var self_add = this[Class.ic__add];
             if ((object)self_add == null)
                 return TrObject.__add__(this, a);
             return self_add.Call(a);
         }
-        TrObject TrObject.__sub__(TrObject a)
+        public override TrObject __sub__(TrObject a)
         {
             var self_sub = this[Class.ic__sub];
             if ((object)self_sub == null)
                 return TrObject.__sub__(this, a);
             return self_sub.Call(a);
         }
-        TrObject TrObject.__mul__(TrObject a)
+        public override TrObject __mul__(TrObject a)
         {
             var self_mul = this[Class.ic__mul];
             if ((object)self_mul == null)
                 return TrObject.__mul__(this, a);
             return self_mul.Call(a);
         }
-        TrObject TrObject.__matmul__(TrObject a)
+        public override TrObject __matmul__(TrObject a)
         {
             var self_matmul = this[Class.ic__matmul];
             if ((object)self_matmul == null)
                 return TrObject.__matmul__(this, a);
             return self_matmul.Call(a);
         }
-        TrObject TrObject.__floordiv__(TrObject a)
+        public override TrObject __floordiv__(TrObject a)
         {
             var self_floordiv = this[Class.ic__floordiv];
             if ((object)self_floordiv == null)
                 return TrObject.__floordiv__(this, a);
             return self_floordiv.Call(a);
         }
-        TrObject TrObject.__truediv__(TrObject a)
+        public override TrObject __truediv__(TrObject a)
         {
             var self_truediv = this[Class.ic__truediv];
             if ((object)self_truediv == null)
                 return TrObject.__truediv__(this, a);
             return self_truediv.Call(a);
         }
-        TrObject TrObject.__mod__(TrObject a)
+        public override TrObject __mod__(TrObject a)
         {
             var self_mod = this[Class.ic__mod];
             if ((object)self_mod == null)
                 return TrObject.__mod__(this, a);
             return self_mod.Call(a);
         }
-        TrObject TrObject.__pow__(TrObject a)
+        public override TrObject __pow__(TrObject a)
         {
             var self_pow = this[Class.ic__pow];
             if ((object)self_pow == null)
                 return TrObject.__pow__(this, a);
             return self_pow.Call(a);
         }
-        TrObject TrObject.__bitand__(TrObject a)
+        public override TrObject __bitand__(TrObject a)
         {
             var self_bitand = this[Class.ic__bitand];
             if ((object)self_bitand == null)
                 return TrObject.__bitand__(this, a);
             return self_bitand.Call(a);
         }
-        TrObject TrObject.__bitor__(TrObject a)
+        public override TrObject __bitor__(TrObject a)
         {
             var self_bitor = this[Class.ic__bitor];
             if ((object)self_bitor == null)
                 return TrObject.__bitor__(this, a);
             return self_bitor.Call(a);
         }
-        TrObject TrObject.__bitxor__(TrObject a)
+        public override TrObject __bitxor__(TrObject a)
         {
             var self_bitxor = this[Class.ic__bitxor];
             if ((object)self_bitxor == null)
                 return TrObject.__bitxor__(this, a);
             return self_bitxor.Call(a);
         }
-        TrObject TrObject.__lshift__(TrObject a)
+        public override TrObject __lshift__(TrObject a)
         {
             var self_lshift = this[Class.ic__lshift];
             if ((object)self_lshift == null)
                 return TrObject.__lshift__(this, a);
             return self_lshift.Call(a);
         }
-        TrObject TrObject.__rshift__(TrObject a)
+        public override TrObject __rshift__(TrObject a)
         {
             var self_rshift = this[Class.ic__rshift];
             if ((object)self_rshift == null)
                 return TrObject.__rshift__(this, a);
             return self_rshift.Call(a);
         }
-        Int32 TrObject.__hash__()
+        public override Int32 __hash__()
         {
             var self_hash = this[Class.ic__hash];
             if ((object)self_hash == null)
                 return TrObject.__hash__(this);
             return self_hash.Call().AsInt();
         }
-        TrObject TrObject.__call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
+        public override TrObject __call__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {
             var self_call = this[Class.ic__call];
             if ((object)self_call == null)
                 return TrObject.__call__(this, args, kwargs);
             return self_call.__call__(args, kwargs);
         }
-        Boolean TrObject.__contains__(TrObject a)
+        public override Boolean __contains__(TrObject a)
         {
             var self_contains = this[Class.ic__contains];
             if ((object)self_contains == null)
                 return TrObject.__contains__(this, a);
             return self_contains.Call(a).AsBool();
         }
-        TrObject TrObject.__reversed__()
+        public override TrObject __reversed__()
         {
             var self_reversed = this[Class.ic__reversed];
             if ((object)self_reversed == null)
                 return TrObject.__reversed__(this);
             return self_reversed.Call();
         }
-        TrObject TrObject.__getitem__(TrObject item)
+        public override TrObject __getitem__(TrObject item)
         {
             var self_getitem = this[Class.ic__getitem];
             if ((object)self_getitem == null)
@@ -160,7 +160,7 @@ namespace Traffy.Objects
             return self_getitem.Call(item);
         }
 
-        void TrObject.__setitem__(TrObject key, TrObject value)
+        public override void __setitem__(TrObject key, TrObject value)
         {
             var self_setitem = this[Class.ic__setitem];
             if ((object)self_setitem == null)
@@ -171,7 +171,7 @@ namespace Traffy.Objects
             self_setitem.Call(key, value);
         }
 
-        void TrObject.__delitem__(TrObject key)
+        public override void __delitem__(TrObject key)
         {
             var self_delitem = this[Class.ic__delitem];
             if ((object)self_delitem == null)
@@ -182,105 +182,105 @@ namespace Traffy.Objects
             self_delitem.Call(key);
         }
 
-        IEnumerator<TrObject> TrObject.__iter__()
+        public override IEnumerator<TrObject> __iter__()
         {
             var self_iter = this[Class.ic__iter];
             if ((object)self_iter == null)
                 return TrObject.__iter__(this);
             return self_iter.Call().__iter__();
         }
-        TrObject TrObject.__len__()
+        public override TrObject __len__()
         {
             var self_len = this[Class.ic__len];
             if ((object)self_len == null)
                 return TrObject.__len__(this);
             return self_len.Call();
         }
-        Boolean TrObject.__eq__(TrObject other)
+        public override Boolean __eq__(TrObject other)
         {
             var self_eq = this[Class.ic__eq];
             if ((object)self_eq == null)
                 return TrObject.__eq__(this, other);
             return self_eq.Call(other).AsBool();
         }
-        Boolean TrObject.__ne__(TrObject other)
+        public override Boolean __ne__(TrObject other)
         {
             var self_ne = this[Class.ic__ne];
             if ((object)self_ne == null)
                 return TrObject.__ne__(this, other);
             return self_ne.Call(other).AsBool();
         }
-        Boolean TrObject.__lt__(TrObject other)
+        public override Boolean __lt__(TrObject other)
         {
             var self_lt = this[Class.ic__lt];
             if ((object)self_lt == null)
                 return TrObject.__lt__(this, other);
             return self_lt.Call(other).AsBool();
         }
-        Boolean TrObject.__le__(TrObject other)
+        public override Boolean __le__(TrObject other)
         {
             var self_le = this[Class.ic__le];
             if ((object)self_le == null)
                 return TrObject.__le__(this, other);
             return self_le.Call(other).AsBool();
         }
-        Boolean TrObject.__gt__(TrObject other)
+        public override Boolean __gt__(TrObject other)
         {
             var self_gt = this[Class.ic__gt];
             if ((object)self_gt == null)
                 return TrObject.__gt__(this, other);
             return self_gt.Call(other).AsBool();
         }
-        Boolean TrObject.__ge__(TrObject other)
+        public override Boolean __ge__(TrObject other)
         {
             var self_ge = this[Class.ic__ge];
             if ((object)self_ge == null)
                 return TrObject.__ge__(this, other);
             return self_ge.Call(other).AsBool();
         }
-        TrObject TrObject.__neg__()
+        public override TrObject __neg__()
         {
             var self_neg = this[Class.ic__neg];
             if ((object)self_neg == null)
                 return TrObject.__neg__(this);
             return self_neg.Call();
         }
-        TrObject TrObject.__invert__()
+        public override TrObject __invert__()
         {
             var self_invert = this[Class.ic__invert];
             if ((object)self_invert == null)
                 return TrObject.__invert__(this);
             return self_invert.Call();
         }
-        TrObject TrObject.__pos__()
+        public override TrObject __pos__()
         {
             var self_pos = this[Class.ic__pos];
             if ((object)self_pos == null)
                 return TrObject.__pos__(this);
             return self_pos.Call();
         }
-        Boolean TrObject.__bool__()
+        public override Boolean __bool__()
         {
             var self_bool = this[Class.ic__bool];
             if ((object)self_bool == null)
                 return TrObject.__bool__(this);
             return self_bool.Call().AsBool();
         }
-        TrObject TrObject.__abs__()
+        public override TrObject __abs__()
         {
             var self_abs = this[Class.ic__abs];
             if ((object)self_abs == null)
                 return TrObject.__abs__(this);
             return self_abs.Call();
         }
-        TrObject TrObject.__enter__()
+        public override TrObject __enter__()
         {
             var self_enter = this[Class.ic__enter];
             if ((object)self_enter == null)
                 return TrObject.__enter__(this);
             return self_enter.Call();
         }
-        TrObject TrObject.__exit__(TrObject exc_type, TrObject exc_value, TrObject traceback)
+        public override TrObject __exit__(TrObject exc_type, TrObject exc_value, TrObject traceback)
         {
             var self_exit = this[Class.ic__exit];
             if ((object)self_exit == null)

--- a/UnityPython.BackEnd/src/Traffy.Objects/UserObject.cs
+++ b/UnityPython.BackEnd/src/Traffy.Objects/UserObject.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System;
 namespace Traffy.Objects
 {
-    public partial interface TrUserObjectBase: TrObject
+    public interface TrUserObjectBase: TrObject
     {
         TrObject TrObject.__init__(BList<TrObject> args, Dictionary<TrObject, TrObject> kwargs)
         {

--- a/UnityPython.BackEnd/src/Traffy.Runtime/Conversion.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/Conversion.cs
@@ -62,10 +62,10 @@ namespace Traffy
             return o;
         }
 
-        public static T Apply<T>(THint<T> _, TrObject o) where T : class, TrObject
+        public static T Apply<T>(THint<T> _, TrObject o) where T : TrObject
         {
             var s_o = o as T;
-            if ((object) s_o != null)
+            if ((object)s_o != null)
             {
                 return s_o;
             }

--- a/UnityPython.BackEnd/src/Traffy.Runtime/Frame.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/Frame.cs
@@ -1,8 +1,8 @@
 using System;
-using Traffy.Objects;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using Traffy.Objects;
 
 namespace Traffy
 {
@@ -290,7 +290,7 @@ namespace Traffy
         internal TrObject load_local(int operand)
         {
             var v = localvars[operand].Value;
-            if(v == null)
+            if (v == null)
                 throw undef_local(operand);
             return v;
         }
@@ -299,7 +299,7 @@ namespace Traffy
         internal TrObject load_free(int operand)
         {
             var v = freevars[operand].Value;
-            if(v == null)
+            if (v == null)
                 throw undef_free(operand);
             return v;
         }
@@ -380,7 +380,7 @@ namespace Traffy
         }
     }
 
-    public struct SuppressControlFlow: IDisposable
+    public struct SuppressControlFlow : IDisposable
     {
         public STATUS CONT;
         public Frame Frame;
@@ -399,7 +399,7 @@ namespace Traffy
 
         public void Dispose()
         {
-            Frame.CONT =  MostSevere(Frame.CONT, CONT);
+            Frame.CONT = MostSevere(Frame.CONT, CONT);
         }
     }
 }

--- a/UnityPython.BackEnd/src/Traffy.Runtime/NumberMethods.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/NumberMethods.cs
@@ -6,12 +6,7 @@ using uint_t = System.UInt64;
 namespace Traffy.Objects
 {
 
-#if NUNITY
-using static System.MathF;
-#else
-using static UnityEngine.Mathf;
-#endif
-
+    using static System.MathF;
     public static class NumberMethods
     {
         static int_t s_intmod(int_t a, int_t b)

--- a/UnityPython.BackEnd/src/Traffy.Runtime/NumberMethods.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/NumberMethods.cs
@@ -420,66 +420,66 @@ namespace Traffy.Objects
 
     public partial class TrFloat
     {
-        public TrObject __add__(TrObject o) => NumberMethods.float_add(this, o);
-        public TrObject __sub__(TrObject o) => NumberMethods.float_sub(this, o);
-        public TrObject __mul__(TrObject o) => NumberMethods.float_mul(this, o);
-        public TrObject __floordiv__(TrObject o) => NumberMethods.float_floordiv(this, o);
-        public TrObject __truediv__(TrObject o) => NumberMethods.float_truediv(this, o);
+        public override TrObject __add__(TrObject o) => NumberMethods.float_add(this, o);
+        public override TrObject __sub__(TrObject o) => NumberMethods.float_sub(this, o);
+        public override TrObject __mul__(TrObject o) => NumberMethods.float_mul(this, o);
+        public override TrObject __floordiv__(TrObject o) => NumberMethods.float_floordiv(this, o);
+        public override TrObject __truediv__(TrObject o) => NumberMethods.float_truediv(this, o);
 
-        public TrObject __mod__(TrObject o) => NumberMethods.float_mod(this, o);
+        public override TrObject __mod__(TrObject o) => NumberMethods.float_mod(this, o);
 
-        public TrObject __pow__(TrObject o) => NumberMethods.float_pow(this, o);
+        public override TrObject __pow__(TrObject o) => NumberMethods.float_pow(this, o);
 
-        public bool __eq__(TrObject o) => NumberMethods.float_t_eq(this, o);
+        public override bool __eq__(TrObject o) => NumberMethods.float_t_eq(this, o);
 
-        public bool __ne__(TrObject o) => NumberMethods.float_t_ne(this, o);
+        public override bool __ne__(TrObject o) => NumberMethods.float_t_ne(this, o);
 
-        public bool __lt__(TrObject o) => NumberMethods.float_t_lt(this, o);
+        public override bool __lt__(TrObject o) => NumberMethods.float_t_lt(this, o);
 
-        public bool __gt__(TrObject o) => NumberMethods.float_t_gt(this, o);
+        public override bool __gt__(TrObject o) => NumberMethods.float_t_gt(this, o);
 
-        public bool __le__(TrObject o) => NumberMethods.float_t_le(this, o);
+        public override bool __le__(TrObject o) => NumberMethods.float_t_le(this, o);
 
-        public bool __ge__(TrObject o) => NumberMethods.float_t_ge(this, o);
-        public TrObject __neg__() => MK.Float(-value);
-        public TrObject __pos__() => this;
+        public override bool __ge__(TrObject o) => NumberMethods.float_t_ge(this, o);
+        public override TrObject __neg__() => MK.Float(-value);
+        public override TrObject __pos__() => this;
     }
 
     public partial class TrInt
     {
-        public TrObject __add__(TrObject o) => NumberMethods.int_t_add(this, o);
-        public TrObject __sub__(TrObject o) => NumberMethods.int_t_sub(this, o);
-        public TrObject __mul__(TrObject o) => NumberMethods.int_t_mul(this, o);
+        public override TrObject __add__(TrObject o) => NumberMethods.int_t_add(this, o);
+        public override TrObject __sub__(TrObject o) => NumberMethods.int_t_sub(this, o);
+        public override TrObject __mul__(TrObject o) => NumberMethods.int_t_mul(this, o);
 
-        public TrObject __floordiv__(TrObject o) => NumberMethods.int_t_floordiv(this, o);
-        public TrObject __truediv__(TrObject o) => NumberMethods.int_t_truediv(this, o);
+        public override TrObject __floordiv__(TrObject o) => NumberMethods.int_t_floordiv(this, o);
+        public override TrObject __truediv__(TrObject o) => NumberMethods.int_t_truediv(this, o);
 
-        public TrObject __mod__(TrObject o) => NumberMethods.int_t_mod(this, o);
+        public override TrObject __mod__(TrObject o) => NumberMethods.int_t_mod(this, o);
 
-        public TrObject __pow__(TrObject o) => NumberMethods.int_t_pow(this, o);
+        public override TrObject __pow__(TrObject o) => NumberMethods.int_t_pow(this, o);
 
-        public TrObject __lshift__(TrObject o) => NumberMethods.int_t_lshift(this, o);
+        public override TrObject __lshift__(TrObject o) => NumberMethods.int_t_lshift(this, o);
 
-        public TrObject __rshift__(TrObject o) => NumberMethods.int_t_rshift(this, o);
+        public override TrObject __rshift__(TrObject o) => NumberMethods.int_t_rshift(this, o);
 
-        public bool __eq__(TrObject o) => NumberMethods.int_t_eq(this, o);
+        public override bool __eq__(TrObject o) => NumberMethods.int_t_eq(this, o);
 
-        public bool __ne__(TrObject o) => NumberMethods.int_t_ne(this, o);
+        public override bool __ne__(TrObject o) => NumberMethods.int_t_ne(this, o);
 
-        public bool __lt__(TrObject o) => NumberMethods.int_t_lt(this, o);
+        public override bool __lt__(TrObject o) => NumberMethods.int_t_lt(this, o);
 
-        public bool __gt__(TrObject o) => NumberMethods.int_t_gt(this, o);
+        public override bool __gt__(TrObject o) => NumberMethods.int_t_gt(this, o);
 
-        public bool __le__(TrObject o) => NumberMethods.int_t_le(this, o);
+        public override bool __le__(TrObject o) => NumberMethods.int_t_le(this, o);
 
-        public bool __ge__(TrObject o) => NumberMethods.int_t_ge(this, o);
+        public override bool __ge__(TrObject o) => NumberMethods.int_t_ge(this, o);
 
-        public TrObject __bitand__(TrObject o) => NumberMethods.int_t_bitand(this, o);
-        public TrObject __bitor__(TrObject o) => NumberMethods.int_t_bitor(this, o);
-        public TrObject __bitxor__(TrObject o) => NumberMethods.int_t_bitxor(this, o);
+        public override TrObject __bitand__(TrObject o) => NumberMethods.int_t_bitand(this, o);
+        public override TrObject __bitor__(TrObject o) => NumberMethods.int_t_bitor(this, o);
+        public override TrObject __bitxor__(TrObject o) => NumberMethods.int_t_bitxor(this, o);
 
-        public TrObject __neg__() => MK.Int(-value);
-        public TrObject __pos__() => this;
-        public TrObject __invert__() => MK.Int(~value);
+        public override TrObject __neg__() => MK.Int(-value);
+        public override TrObject __pos__() => this;
+        public override TrObject __invert__() => MK.Int(~value);
     }
 }

--- a/UnityPython.BackEnd/src/Traffy.Runtime/RuntimeSystem.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/RuntimeSystem.cs
@@ -501,34 +501,26 @@ namespace Traffy
 
         public static bool exc_check_instance(Exception e, TrObject rt_exc)
         {
-            if (e is TrObject obj)
-            {
-                return obj.__instancecheck__(rt_exc);
-            }
-            if (rt_exc is TrClass cls)
-            {
-                return cls == NativeError.CLASS;
-            }
-            else
-            {
-                throw new TypeError($"exception class must be a class, not '{rt_exc.Class.Name}'.");
-            }
+            var e_obj = exc_frombare(e);
+            return e_obj.__instancecheck__(rt_exc);
         }
 
         public static TrExceptionBase exc_frombare(Exception e)
         {
-            if (e is TrExceptionBase o)
-                return o;
-            return new NativeError(e);
+            throw new NotImplementedException();
+            // if (e is TrExceptionBase o)
+            //     return o;
+            // return new NativeError(e);
         }
 
         public static Exception exc_tobare(TrObject rt_exc)
         {
-            if (rt_exc is Exception o)
-            {
-                return o;
-            }
-            throw new ValueError($"{rt_exc.__repr__()} is not an exception");
+            throw new NotImplementedException();
+            // if (rt_exc is Exception o)
+            // {
+            //     return o;
+            // }
+            // throw new ValueError($"{rt_exc.__repr__()} is not an exception");
         }
 
         public static Awaitable<TrObject> generator_of_iter(IEnumerator<TrObject> o)

--- a/UnityPython.BackEnd/src/Traffy.Runtime/RuntimeSystem.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/RuntimeSystem.cs
@@ -513,10 +513,6 @@ namespace Traffy
             }
             var exc = new NativeError(e);
             return exc;
-
-            // if (e is TrExceptionBase o)
-            //     return o;
-            // return new NativeError(e);
         }
 
         public static Exception exc_tobare(TrObject rt_exc)

--- a/UnityPython.BackEnd/src/Traffy.Runtime/RuntimeSystem.cs
+++ b/UnityPython.BackEnd/src/Traffy.Runtime/RuntimeSystem.cs
@@ -507,7 +507,13 @@ namespace Traffy
 
         public static TrExceptionBase exc_frombare(Exception e)
         {
-            throw new NotImplementedException();
+            if (e is TrExceptionWrapper wrapper)
+            {
+                return wrapper.TrO;
+            }
+            var exc = new NativeError(e);
+            return exc;
+
             // if (e is TrExceptionBase o)
             //     return o;
             // return new NativeError(e);
@@ -515,12 +521,9 @@ namespace Traffy
 
         public static Exception exc_tobare(TrObject rt_exc)
         {
-            throw new NotImplementedException();
-            // if (rt_exc is Exception o)
-            // {
-            //     return o;
-            // }
-            // throw new ValueError($"{rt_exc.__repr__()} is not an exception");
+            if (rt_exc is TrExceptionBase o)
+                new TrExceptionWrapper(o);
+            throw new TypeError($"exceptions must be old-style classes or derived from BaseException, not {rt_exc.Class.Name}");
         }
 
         public static Awaitable<TrObject> generator_of_iter(IEnumerator<TrObject> o)

--- a/UnityPython.BackEnd/src/Utils.cs
+++ b/UnityPython.BackEnd/src/Utils.cs
@@ -13,17 +13,24 @@ public static class Utils
 
     internal static HashSet<string> GetInterfaceMethodSource(this Type t)
     {
-        var interface_t = t.GetInterfaceMap(typeof(Traffy.Objects.TrObject));
-        var res = new HashSet<string>();
-        for(int i = 0; i < interface_t.TargetMethods.Length; i++)
+        var owned = new HashSet<string>();
+        foreach(var mi in t.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            var targetMethod = interface_t.TargetMethods[i];
-            var interfaceMethod = interface_t.InterfaceMethods[i];
-            var methName = interfaceMethod.Name;
-            if (Traffy.MagicNames.ALL.Contains(methName) && interfaceMethod != targetMethod)
-                res.Add(methName);
+            if (mi.GetBaseDefinition().DeclaringType != mi.DeclaringType)
+                owned.Add(mi.Name);
         }
-        return res;
+        return owned;
+        // var interface_t = t.GetInterfaceMap(typeof(Traffy.Objects.TrObject));
+        // var res = new HashSet<string>();
+        // for(int i = 0; i < interface_t.TargetMethods.Length; i++)
+        // {
+        //     var targetMethod = interface_t.TargetMethods[i];
+        //     var interfaceMethod = interface_t.InterfaceMethods[i];
+        //     var methName = interfaceMethod.Name;
+        //     if (Traffy.MagicNames.ALL.Contains(methName) && interfaceMethod != targetMethod)
+        //         res.Add(methName);
+        // }
+        // return res;
     }
 
     internal static List<T> ToList<T>(this IEnumerator<T> self)

--- a/UnityPython.BackEnd/src/Utils.cs
+++ b/UnityPython.BackEnd/src/Utils.cs
@@ -11,27 +11,6 @@ public static class Utils
         return new HashSet<T>(source);
     }
 
-    internal static HashSet<string> GetInterfaceMethodSource(this Type t)
-    {
-        var owned = new HashSet<string>();
-        foreach(var mi in t.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
-        {
-            if (mi.GetBaseDefinition().DeclaringType != mi.DeclaringType)
-                owned.Add(mi.Name);
-        }
-        return owned;
-        // var interface_t = t.GetInterfaceMap(typeof(Traffy.Objects.TrObject));
-        // var res = new HashSet<string>();
-        // for(int i = 0; i < interface_t.TargetMethods.Length; i++)
-        // {
-        //     var targetMethod = interface_t.TargetMethods[i];
-        //     var interfaceMethod = interface_t.InterfaceMethods[i];
-        //     var methName = interfaceMethod.Name;
-        //     if (Traffy.MagicNames.ALL.Contains(methName) && interfaceMethod != targetMethod)
-        //         res.Add(methName);
-        // }
-        // return res;
-    }
 
     internal static List<T> ToList<T>(this IEnumerator<T> self)
     {

--- a/UnityPython.BackEnd/tests/test_normal.py
+++ b/UnityPython.BackEnd/tests/test_normal.py
@@ -119,3 +119,35 @@ xs = [1, 2, -8, 1]
 xs.sort()
 print(xs)
 
+
+def _test1():
+    x = 0
+    for i in range(10000000):
+        x += 1
+        yield x
+
+def test1():
+    x = list(_test1())
+    print(x[50])
+    return len(x)
+
+def test2():
+    x = 0
+    while x < 10000000:
+        x += 1
+    return x
+
+class XX:
+    xx =5
+    def __init__(self, x):
+        self.x = x
+
+
+def testfunc(f):
+    a = time()
+    print("res", f())
+    print(time() - a)
+
+
+testfunc(test1)
+testfunc(test2)


### PR DESCRIPTION
We give up default interface methods because unexpected bugs happen in Unity (mono/il2cpp backends).
Switching to abstract classes works.

So far we still need rewriting the code generators to use abstract class virtual methods instead of default interface methods.

